### PR TITLE
Sort migrations by id in FindMigrations()

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -64,6 +64,9 @@ type MemoryMigrationSource struct {
 var _ MigrationSource = (*MemoryMigrationSource)(nil)
 
 func (m MemoryMigrationSource) FindMigrations() ([]*Migration, error) {
+	// Make sure migrations are sorted
+	sort.Sort(byId(m.Migrations))
+
 	return m.Migrations, nil
 }
 
@@ -102,6 +105,9 @@ func (f FileMigrationSource) FindMigrations() ([]*Migration, error) {
 			migrations = append(migrations, migration)
 		}
 	}
+
+	// Make sure migrations are sorted
+	sort.Sort(byId(migrations))
 
 	return migrations, nil
 }
@@ -143,6 +149,9 @@ func (a AssetMigrationSource) FindMigrations() ([]*Migration, error) {
 			migrations = append(migrations, migration)
 		}
 	}
+
+	// Make sure migrations are sorted
+	sort.Sort(byId(migrations))
 
 	return migrations, nil
 }
@@ -250,9 +259,6 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// Make sure migrations are sorted
-	sort.Sort(byId(migrations))
 
 	// Find the newest applied migration
 	var record MigrationRecord


### PR DESCRIPTION
Motivation: The output of `sql-migrate status` should be sorted.

The other way of implementing this would involve exporting `byId`. I think the migrations are generally more useful when sorted, although it adds a bit of overhead. I'm also not sure whether it's necessary to sort the MemoryMigrationSource as the data could easily be sorted before putting it in there.
