### PR TITLE
Support timestamp 'versions' by falling back to string comparison when to VersionInts() are equal

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -81,7 +81,7 @@ type Migration struct {
 
 func (m Migration) Less(other *Migration) bool {
 	switch {
-	case m.isNumeric() && other.isNumeric():
+	case m.isNumeric() && other.isNumeric() && m.VersionInt()-other.VersionInt() != 0:
 		return m.VersionInt() < other.VersionInt()
 	case m.isNumeric() && !other.isNumeric():
 		return true

--- a/migrate.go
+++ b/migrate.go
@@ -81,7 +81,7 @@ type Migration struct {
 
 func (m Migration) Less(other *Migration) bool {
 	switch {
-	case m.isNumeric() && other.isNumeric() && m.VersionInt()-other.VersionInt() != 0:
+	case m.isNumeric() && other.isNumeric() && m.VersionInt() != other.VersionInt():
 		return m.VersionInt() < other.VersionInt()
 	case m.isNumeric() && !other.isNumeric():
 		return true

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -360,14 +360,18 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithHoles(c *C) {
 	c.Assert(plannedMigrations[2].Queries[0], Equals, down)
 }
 
-func (s *SqliteMigrateSuite) TestLessTwoNumeric(c *C) {
-	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "2"}), Equals, true)      // 1 less than 2
-	c.Assert((Migration{Id: "2"}).Less(&Migration{Id: "1"}), Equals, false)     // 2 not less than 1
-	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "a"}), Equals, true)      // 1 less than a
-	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "1"}), Equals, false)     // a not less than 1
-	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "a"}), Equals, false)     // a not less than a
-	c.Assert((Migration{Id: "1-a"}).Less(&Migration{Id: "1-b"}), Equals, true)  // 1-a less than 1-b
-	c.Assert((Migration{Id: "1-b"}).Less(&Migration{Id: "1-a"}), Equals, false) // 1-b not less than 1-a
+func (s *SqliteMigrateSuite) TestLess(c *C) {
+	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "2"}), Equals, true)           // 1 less than 2
+	c.Assert((Migration{Id: "2"}).Less(&Migration{Id: "1"}), Equals, false)          // 2 not less than 1
+	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "a"}), Equals, true)           // 1 less than a
+	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "1"}), Equals, false)          // a not less than 1
+	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "a"}), Equals, false)          // a not less than a
+	c.Assert((Migration{Id: "1-a"}).Less(&Migration{Id: "1-b"}), Equals, true)       // 1-a less than 1-b
+	c.Assert((Migration{Id: "1-b"}).Less(&Migration{Id: "1-a"}), Equals, false)      // 1-b not less than 1-a
+	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "10"}), Equals, true)          // 1 less than 10
+	c.Assert((Migration{Id: "10"}).Less(&Migration{Id: "1"}), Equals, false)         // 10 not less than 1
+	c.Assert((Migration{Id: "1_foo"}).Less(&Migration{Id: "10_bar"}), Equals, true)  // 1_foo not less than 1
+	c.Assert((Migration{Id: "10_bar"}).Less(&Migration{Id: "1_foo"}), Equals, false) // 10 not less than 1
 	// 20160126_1100 less than 20160126_1200
 	c.Assert((Migration{Id: "20160126_1100"}).
 		Less(&Migration{Id: "20160126_1200"}), Equals, true)

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -359,3 +359,20 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithHoles(c *C) {
 	c.Assert(plannedMigrations[2].Migration.Id, Equals, "2")
 	c.Assert(plannedMigrations[2].Queries[0], Equals, down)
 }
+
+func (s *SqliteMigrateSuite) TestLessTwoNumeric(c *C) {
+	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "2"}), Equals, true)      // 1 less than 2
+	c.Assert((Migration{Id: "2"}).Less(&Migration{Id: "1"}), Equals, false)     // 2 not less than 1
+	c.Assert((Migration{Id: "1"}).Less(&Migration{Id: "a"}), Equals, true)      // 1 less than a
+	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "1"}), Equals, false)     // a not less than 1
+	c.Assert((Migration{Id: "a"}).Less(&Migration{Id: "a"}), Equals, false)     // a not less than a
+	c.Assert((Migration{Id: "1-a"}).Less(&Migration{Id: "1-b"}), Equals, true)  // 1-a less than 1-b
+	c.Assert((Migration{Id: "1-b"}).Less(&Migration{Id: "1-a"}), Equals, false) // 1-b not less than 1-a
+	// 20160126_1100 less than 20160126_1200
+	c.Assert((Migration{Id: "20160126_1100"}).
+		Less(&Migration{Id: "20160126_1200"}), Equals, true)
+	// 20160126_1200 not less than 20160126_1100
+	c.Assert((Migration{Id: "20160126_1200"}).
+		Less(&Migration{Id: "20160126_1100"}), Equals, false)
+
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"database/sql"
+	"io/ioutil"
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -9,7 +10,7 @@ import (
 	"gopkg.in/gorp.v1"
 )
 
-var filename = "/tmp/sql-migrate-sqlite.db"
+var testDatabaseFile *os.File
 var sqliteMigrations = []*Migration{
 	&Migration{
 		Id:   "123",
@@ -31,7 +32,10 @@ type SqliteMigrateSuite struct {
 var _ = Suite(&SqliteMigrateSuite{})
 
 func (s *SqliteMigrateSuite) SetUpTest(c *C) {
-	db, err := sql.Open("sqlite3", filename)
+	var err error
+	testDatabaseFile, err = ioutil.TempFile("", "sql-migrate-sqlite")
+	c.Assert(err, IsNil)
+	db, err := sql.Open("sqlite3", testDatabaseFile.Name())
 	c.Assert(err, IsNil)
 
 	s.Db = db
@@ -39,7 +43,7 @@ func (s *SqliteMigrateSuite) SetUpTest(c *C) {
 }
 
 func (s *SqliteMigrateSuite) TearDownTest(c *C) {
-	err := os.Remove(filename)
+	err := os.Remove(testDatabaseFile.Name())
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
Currently, the two following migrations are considered to have the same version:
```
20160126_1100_migration1.sql
20160126_1200_migration2.sql
```
This happens because only the first number in the ID string is used for comparion, i.e. `20160126` for both migrations. The patch fixes this by falling back to string comparsion when `Migration.VersionInt()` returns the same version for two migrations.

Also, generalize temporary filename used for `migration_test.go` by using `ioutil.TempFile()` to create one.