### PR TITLE
Expand environment variables in datasource

### DIFF
--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/rubenv/sql-migrate"
 	"gopkg.in/gorp.v1"
@@ -71,6 +72,7 @@ func GetEnvironment() (*Environment, error) {
 	if env.DataSource == "" {
 		return nil, errors.New("No data source specified")
 	}
+	env.DataSource = os.ExpandEnv(env.DataSource)
 
 	if env.Dir == "" {
 		env.Dir = "migrations"

--- a/test-integration/dbconfig.yml
+++ b/test-integration/dbconfig.yml
@@ -13,6 +13,11 @@ mysql_noflag:
     datasource: root@/test
     dir: test-migrations
 
+mysql_env:
+    dialect: mysql
+    datasource: ${MYSQL_USER}@/$DATABASE?parseTime=true
+    dir: test-migrations
+
 sqlite:
     dialect: sqlite3
     datasource: test.db

--- a/test-integration/mysql-env.sh
+++ b/test-integration/mysql-env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Tweak PATH for Travis
+export PATH=$PATH:$HOME/gopath/bin
+
+export MYSQL_USER=root
+export DATABASE=test
+
+OPTIONS="-config=test-integration/dbconfig.yml -env mysql_env"
+
+set -ex
+
+sql-migrate status $OPTIONS
+sql-migrate up $OPTIONS
+sql-migrate down $OPTIONS
+sql-migrate redo $OPTIONS
+sql-migrate status $OPTIONS


### PR DESCRIPTION
Environment variable expansion let's you define all or parts of the datasource individually for each user without changing the config.

To use this feature, put `$VARIABLE` or `${VARIABLE}` as placeholder in the datasource string.