### PR TITLE
Support notransaction mode

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -246,18 +246,14 @@ func ParseMigration(id string, r io.ReadSeeker) (*Migration, error) {
 		Id: id,
 	}
 
-	up, err := sqlparse.SplitSQLStatements(r, true)
+	parsed, err := sqlparse.ParseMigration(r)
 	if err != nil {
 		return nil, err
 	}
 
-	down, err := sqlparse.SplitSQLStatements(r, false)
-	if err != nil {
-		return nil, err
-	}
+	m.Up = parsed.UpStatements
+	m.Down = parsed.DownStatements
 
-	m.Up = up
-	m.Down = down
 
 	return m, nil
 }

--- a/migrate.go
+++ b/migrate.go
@@ -306,7 +306,7 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 		for _, stmt := range migration.Queries {
 			if _, err := executor.Exec(stmt); err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
-					trans.Commit()
+					trans.Rollback()
 				}
 
 				return applied, newTxError(migration, err)

--- a/sqlparse/sqlparse.go
+++ b/sqlparse/sqlparse.go
@@ -10,12 +10,16 @@ import (
 )
 
 const (
-	sqlCmdPrefix = "-- +migrate "
+	sqlCmdPrefix        = "-- +migrate "
+	optionNoTransaction = "notransaction"
 )
 
 type ParsedMigration struct {
 	UpStatements   []string
 	DownStatements []string
+
+	DisableTransactionUp   bool
+	DisableTransactionDown bool
 }
 
 // Checks the line to see if the line has a statement-ending semicolon
@@ -116,10 +120,16 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 			switch cmd.Command {
 			case "Up":
 				currentDirection = directionUp
+				if cmd.HasOption(optionNoTransaction) {
+					p.DisableTransactionUp = true
+				}
 				break
 
 			case "Down":
 				currentDirection = directionDown
+				if cmd.HasOption(optionNoTransaction) {
+					p.DisableTransactionDown = true
+				}
 				break
 
 			case "StatementBegin":

--- a/sqlparse/sqlparse_test.go
+++ b/sqlparse/sqlparse_test.go
@@ -56,37 +56,28 @@ func (s *SqlParseSuite) TestSemicolons(c *C) {
 func (s *SqlParseSuite) TestSplitStatements(c *C) {
 	type testData struct {
 		sql       string
-		direction bool
-		count     int
+		upCount   int
+		downCount int
 	}
 
 	tests := []testData{
 		{
 			sql:       functxt,
-			direction: true,
-			count:     2,
-		},
-		{
-			sql:       functxt,
-			direction: false,
-			count:     2,
+			upCount:   2,
+			downCount: 2,
 		},
 		{
 			sql:       multitxt,
-			direction: true,
-			count:     2,
-		},
-		{
-			sql:       multitxt,
-			direction: false,
-			count:     2,
+			upCount:   2,
+			downCount: 2,
 		},
 	}
 
 	for _, test := range tests {
-		stmts, err := SplitSQLStatements(strings.NewReader(test.sql), test.direction)
+		migration, err := ParseMigration(strings.NewReader(test.sql))
 		c.Assert(err, IsNil)
-		c.Assert(stmts, HasLen, test.count)
+		c.Assert(migration.UpStatements, HasLen, test.upCount)
+		c.Assert(migration.DownStatements, HasLen, test.downCount)
 	}
 }
 


### PR DESCRIPTION
This PR fixes #13 by:
1. Refactoring the parser to allow sql-migrate commands to take options
2. Adds a "notransaction" option to the "Up" and "Down" commands as suggested in #13 
3. Honors the "notransaction" option by using the raw `DbMap` for database calls instead of creating a transaction
