### PR TITLE
Adding guards to allow working with multiple migration directories

### DIFF
--- a/sql-migrate/command_status.go
+++ b/sql-migrate/command_status.go
@@ -77,17 +77,22 @@ func (c *StatusCommand) Run(args []string) int {
 
 	for _, m := range migrations {
 		rows[m.Id] = &statusRow{
-			Id:       m.Id,
-			Migrated: false,
+			Id: m.Id,
 		}
 	}
 
 	for _, r := range records {
+		if _, ok := rows[r.Id]; !ok {
+			continue
+		}
 		rows[r.Id].Migrated = true
 		rows[r.Id].AppliedAt = r.AppliedAt
 	}
 
 	for _, m := range migrations {
+		if _, ok := rows[m.Id]; !ok {
+			continue
+		}
 		if rows[m.Id].Migrated {
 			table.Append([]string{
 				m.Id,


### PR DESCRIPTION
Adding guards so that working with multiple migration directories doesn't give any troubles.

Tree:

```
├── db1
│   ├── dbconfig.yml
│   └── migrations
│       └── 0_initial-content.sql
├── db2
│   ├── dbconfig.yml
│   └── migrations
│       ├── 0_initial-content.sql
│       ├── 1_stuff.sql
│       └── 2_foo.sql
└── sql-migrate
```

The use-case being that you can do:

``` sh
$ cd db2
$ ../sql-migrate up
```

In our situation we have just a single database for development and separated database on other environments. This makes it easier to apply all patches to a single database.

Without this PR the result will be:

``` sh
$ ../sql-migrate status
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x40048a2]

goroutine 1 [running]:
panic(0x4430240, 0xc4200100e0)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
main.(*StatusCommand).Run(0x471aa40, 0xc420088070, 0x0, 0x0, 0x44acfb0)
    /GO/src/github.com/rubenv/sql-migrate/sql-migrate/command_status.go:86 +0x4e2
github.com/mitchellh/cli.(*CLI).Run(0xc420408000, 0xc42007c330, 0xc42003af10, 0xc42003aef8)
    /GO/src/github.com/mitchellh/cli/cli.go:154 +0x24e
main.realMain(0xc4200001a0)
    /GO/src/github.com/rubenv/sql-migrate/sql-migrate/main.go:39 +0x385
main.main()
    /GO/src/github.com/rubenv/sql-migrate/sql-migrate/main.go:11 +0x22

```
