### PR TITLE
Quote tableName when querying migrations

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -64,15 +64,6 @@ func SetSchema(name string) {
 	}
 }
 
-func getTableName() string {
-	t := tableName
-	if schemaName != "" {
-		t = fmt.Sprintf("%s.%s", schemaName, t)
-	}
-
-	return t
-}
-
 type Migration struct {
 	Id   string
 	Up   []string
@@ -357,7 +348,7 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	}
 
 	var migrationRecords []MigrationRecord
-	_, err = dbMap.Select(&migrationRecords, fmt.Sprintf("SELECT * FROM %s", getTableName()))
+	_, err = dbMap.Select(&migrationRecords, fmt.Sprintf("SELECT * FROM %s", dbMap.Dialect.QuotedTableForQuery(schemaName, tableName)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -469,7 +460,7 @@ func GetMigrationRecords(db *sql.DB, dialect string) ([]*MigrationRecord, error)
 	}
 
 	var records []*MigrationRecord
-	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id ASC", getTableName())
+	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id ASC", dbMap.Dialect.QuotedTableForQuery(schemaName, tableName))
 	_, err = dbMap.Select(&records, query)
 	if err != nil {
 		return nil, err

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -67,6 +67,19 @@ func (s *SqliteMigrateSuite) TestRunMigration(c *C) {
 	c.Assert(n, Equals, 0)
 }
 
+func (s *SqliteMigrateSuite) TestRunMigrationEscapeTable(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: sqliteMigrations[:1],
+	}
+
+	SetTable(`my migrations`)
+
+	// Executes one migration
+	n, err := Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+}
+
 func (s *SqliteMigrateSuite) TestMigrateMultiple(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: sqliteMigrations[:2],


### PR DESCRIPTION
Previously the table name wasn't being quoted (for example when the table name was `migrations-web`) and resulted in the error:

```
Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax
 to use near '-web' at line 1
```

 This uses gorp's functions to correctly handle schemaName (if set) and tableName for the dialects of SQL it supports.