### PR TITLE
Allow custom line terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ DROP TABLE people;
 
 You can put multiple statements in each block, as long as you end them with a semicolon (`;`).
 
+You can alternatively set up a separator string that matches an entire line by setting `sqlparse.LineSeparator`. This
+can be used to imitate, for example, MS SQL Query Analyzer functionality where commands can be separated by a line with
+contents of `GO`. If `sqlparse.LineSeparator` is matched, it will not be included in the resulting migration scripts.
+
 If you have complex statements which contain semicolons, use `StatementBegin` and `StatementEnd` to indicate boundaries:
 
 ```sql

--- a/sqlparse/sqlparse.go
+++ b/sqlparse/sqlparse.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 
 	"strings"
@@ -23,9 +24,23 @@ type ParsedMigration struct {
 }
 
 var (
-	errNoTerminator = errors.New(`ERROR: The last statement must be ended by a semicolon or '-- +migrate StatementEnd' marker.
-			See https://github.com/rubenv/sql-migrate for details.`)
+	// LineSeparator can be used to split migrations by an exact line match. This line
+	// will be removed from the output. If left blank, it is not considered. It is defaulted
+	// to blank so you will have to set it manually.
+	// Use case: in MSSQL, it is convenient to separate commands by GO statements like in
+	// SQL Query Analyzer.
+	LineSeparator = ""
 )
+
+func errNoTerminator() error {
+	if len(LineSeparator) == 0 {
+		return errors.New(`ERROR: The last statement must be ended by a semicolon or '-- +migrate StatementEnd' marker.
+			See https://github.com/rubenv/sql-migrate for details.`)
+	}
+
+	return errors.New(fmt.Sprintf(`ERROR: The last statement must be ended by a semicolon, a line whose contents are %q, or '-- +migrate StatementEnd' marker.
+			See https://github.com/rubenv/sql-migrate for details.`, LineSeparator))
+}
 
 // Checks the line to see if the line has a statement-ending semicolon
 // or if the line contains a double-dash comment.
@@ -125,7 +140,7 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 			switch cmd.Command {
 			case "Up":
 				if len(strings.TrimSpace(buf.String())) > 0 {
-					return nil, errNoTerminator
+					return nil, errNoTerminator()
 				}
 				currentDirection = directionUp
 				if cmd.HasOption(optionNoTransaction) {
@@ -135,7 +150,7 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 
 			case "Down":
 				if len(strings.TrimSpace(buf.String())) > 0 {
-					return nil, errNoTerminator
+					return nil, errNoTerminator()
 				}
 				currentDirection = directionDown
 				if cmd.HasOption(optionNoTransaction) {
@@ -162,14 +177,18 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 			continue
 		}
 
-		if _, err := buf.WriteString(line + "\n"); err != nil {
-			return nil, err
+		isLineSeparator := !ignoreSemicolons && len(LineSeparator) > 0 && line == LineSeparator
+
+		if !isLineSeparator {
+			if _, err := buf.WriteString(line + "\n"); err != nil {
+				return nil, err
+			}
 		}
 
 		// Wrap up the two supported cases: 1) basic with semicolon; 2) psql statement
 		// Lines that end with semicolon that are in a statement block
 		// do not conclude statement.
-		if (!ignoreSemicolons && endsWithSemicolon(line)) || statementEnded {
+		if (!ignoreSemicolons && (endsWithSemicolon(line) || isLineSeparator)) || statementEnded {
 			statementEnded = false
 			switch currentDirection {
 			case directionUp:
@@ -201,7 +220,7 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 	}
 
 	if len(strings.TrimSpace(buf.String())) > 0 {
-		return nil, errNoTerminator
+		return nil, errNoTerminator()
 	}
 
 	return p, nil

--- a/sqlparse/sqlparse_test.go
+++ b/sqlparse/sqlparse_test.go
@@ -88,6 +88,37 @@ func (s *SqlParseSuite) TestIntentionallyBadStatements(c *C) {
 	}
 }
 
+func (s *SqlParseSuite) TestCustomTerminator(c *C) {
+	LineSeparator = "GO"
+	defer func() { LineSeparator = "" }()
+
+	type testData struct {
+		sql       string
+		upCount   int
+		downCount int
+	}
+
+	tests := []testData{
+		{
+			sql:       functxtSplitByGO,
+			upCount:   2,
+			downCount: 2,
+		},
+		{
+			sql:       multitxtSplitByGO,
+			upCount:   2,
+			downCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		migration, err := ParseMigration(strings.NewReader(test.sql))
+		c.Assert(err, IsNil)
+		c.Assert(migration.UpStatements, HasLen, test.upCount)
+		c.Assert(migration.DownStatements, HasLen, test.downCount)
+	}
+}
+
 var functxt = `-- +migrate Up
 CREATE TABLE IF NOT EXISTS histories (
   id                BIGSERIAL  PRIMARY KEY,
@@ -255,3 +286,73 @@ CREATE TABLE fancier_post (
 DROP TABLE fancier_post;
 `,
 }
+
+// Same as functxt above but split by GO lines
+var functxtSplitByGO = `-- +migrate Up
+CREATE TABLE IF NOT EXISTS histories (
+  id                BIGSERIAL  PRIMARY KEY,
+  current_value     varchar(2000) NOT NULL,
+  created_at      timestamp with time zone  NOT NULL
+)
+GO
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION histories_partition_creation( DATE, DATE )
+returns void AS $$
+DECLARE
+  create_query text;
+BEGIN
+  FOR create_query IN SELECT
+      'CREATE TABLE IF NOT EXISTS histories_'
+      || TO_CHAR( d, 'YYYY_MM' )
+      || ' ( CHECK( created_at >= timestamp '''
+      || TO_CHAR( d, 'YYYY-MM-DD 00:00:00' )
+      || ''' AND created_at < timestamp '''
+      || TO_CHAR( d + INTERVAL '1 month', 'YYYY-MM-DD 00:00:00' )
+      || ''' ) ) inherits ( histories );'
+    FROM generate_series( $1, $2, '1 month' ) AS d
+  LOOP
+    EXECUTE create_query;
+  END LOOP;  -- LOOP END
+END;         -- FUNCTION END
+$$
+GO
+/* while GO wouldn't be used in a statement like this, I'm including it for the test */
+language plpgsql
+-- +migrate StatementEnd
+
+-- +migrate Down
+drop function histories_partition_creation(DATE, DATE)
+GO
+drop TABLE histories
+GO
+`
+
+// test multiple up/down transitions in a single script, split by GO lines
+var multitxtSplitByGO = `-- +migrate Up
+CREATE TABLE post (
+    id int NOT NULL,
+    title text,
+    body text,
+    PRIMARY KEY(id)
+)
+GO
+
+-- +migrate Down
+DROP TABLE post
+GO
+
+-- +migrate Up
+CREATE TABLE fancier_post (
+    id int NOT NULL,
+    title text,
+    body text,
+    created_on timestamp without time zone,
+    PRIMARY KEY(id)
+)
+GO
+
+-- +migrate Down
+DROP TABLE fancier_post
+GO
+`


### PR DESCRIPTION
This PR adds the ability to specify a string that, if matched, will split up a list of migrations. This suits our workflow on MS SQL projects, where semicolons are optional and statements are separated by a line containing only the word `GO`, as in MS SQL Query Analyzer.

This PR also includes the line terminator bug fix from https://github.com/rubenv/sql-migrate/pull/53