### PR TITLE
Possibility to configure the date format for the prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ $ sql-migrate status
 | 2_record.sql  | no                                      |
 +---------------+-----------------------------------------+
 ```
+#### Migration Prefix
+
+The `new` command will prefix the generated `.sql` files. This prefix is created using the 
+the [Format](https://golang.org/pkg/time/#Time.Format) function of the golang `time` package. 
+
+You can change the format globally or per environment using the `migration-prefix-timeformat`.
+
+If an environment does not define a format, he will the the global one.
+If no format is defined globally, the default one is used.
+The default format is `20060201150405`.
+
+```yml
+# If specified, it will override 
+# the global format.
+migration-prefix-timeformat: "20060201150405"
+
+# Development will use its
+# own format.
+development:
+    dialect: sqlite3
+    datasource: test.db
+    dir: migrations
+    migration-prefix-timeformat: "2006"
+
+# production will use the global format.
+production:
+    dialect: postgres
+    datasource: dbname=myapp sslmode=disable
+    dir: migrations/postgres
+    table: migrations
+```
 
 ### As a library
 Import sql-migrate into your application:

--- a/sql-migrate/command_new.go
+++ b/sql-migrate/command_new.go
@@ -76,7 +76,7 @@ func CreateMigration(name string) error {
 		return err
 	}
 
-	fileName := fmt.Sprintf("%s-%s.sql", time.Now().Format("20060201150405"), strings.TrimSpace(name))
+	fileName := fmt.Sprintf("%s-%s.sql", time.Now().Format(env.TimeFormat), strings.TrimSpace(name))
 	f, err := os.Create(path.Join(env.Dir, fileName))
 
 	if err != nil {


### PR DESCRIPTION
Add a configuration option within the configuration file that allows to
override the default date format used to prefix the `sql`files.

The format can be set globally or per environment.