### PR TITLE
Create a migration from the first non-flag arg

### DIFF
--- a/sql-migrate/command_new.go
+++ b/sql-migrate/command_new.go
@@ -59,7 +59,7 @@ func (c *NewCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := CreateMigration(args[0]); err != nil {
+	if err := CreateMigration(cmdFlags.Arg(0)); err != nil {
 		ui.Error(err.Error())
 		return 1
 	}


### PR DESCRIPTION
Currently, `sql-migrate new -env="foo" name` will pick `-env="foo"` as the name. This changes it to use the first argument that isn't a flag rather than simply the first argument.