### PR TITLE
Refactor time.Now().Format("20060201150405")

### DIFF
--- a/sql-migrate/command_new.go
+++ b/sql-migrate/command_new.go
@@ -76,7 +76,7 @@ func CreateMigration(name string) error {
 		return err
 	}
 
-	fileName := fmt.Sprintf("%s-%s.sql", time.Now().Format("20060201150405"), strings.TrimSpace(name))
+	fileName := fmt.Sprintf("%s-%s.sql", time.Now().Format("20060102150405"), strings.TrimSpace(name))
 	f, err := os.Create(path.Join(env.Dir, fileName))
 
 	if err != nil {


### PR DESCRIPTION
Change time.Now().Format("20060201150405") to time.Now().Format("20060102150405")
Because golang decides the order of date format.
1 = month
2 = day
FYI: https://golang.org/src/time/format.go

ref. #65 