### PR TITLE
Limit the ID column length of the migration table to fix issue with mssql

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -117,7 +117,7 @@ func (b byId) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byId) Less(i, j int) bool { return b[i].Less(b[j]) }
 
 type MigrationRecord struct {
-	Id        string    `db:"id"`
+	Id        string    `db:"id,size:450"`
 	AppliedAt time.Time `db:"applied_at"`
 }
 


### PR DESCRIPTION
On mssql there is an issue creating the migrations table.
Error reported in the golang error:

```
Could not create constraint or index. See previous errors.
```

This is due to the creation of the migration table as follow
```
if object_id('gorp_migrations') is null create table [gorp_migrations] ([id] nvarchar(max) not null primary key, [applied_at] datetime2) ;;
```
The full error message when manually executing the query:
```
[S0001][1919] Column 'id' in table 'gorp_migrations' is of a type that is invalid for use as a key column in an index.
````

The error caused by the limitation of mssql.
Read more here:
https://msdn.microsoft.com/en-us/library/ms191241.aspx

This PR will limit the length of the id field in 450 characters, which should be sufficient to store the file names of the migrations. Mssql will only use the first 900 bytes for indexing, and nvarchar used 2bytes / character for storage.
