### PR TITLE
Support custom MigrationRecord types/tables

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -349,7 +349,7 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 
 	var migrationRecords []MigrationRecord
 	_, err = dbMap.Select(&migrationRecords, fmt.Sprintf("SELECT * FROM %s", dbMap.Dialect.QuotedTableForQuery(schemaName, tableName)))
-	if err != nil {
+	if err != nil && !gorp.NonFatalError(err) {
 		return nil, nil, err
 	}
 

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -393,3 +393,23 @@ func (s *SqliteMigrateSuite) TestLess(c *C) {
 		Less(&Migration{Id: "20160126_1100"}), Equals, false)
 
 }
+
+func (s *SqliteMigrateSuite) TestCustomMigrationRecord(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: sqliteMigrations[:1],
+	}
+
+	type CustomMigrationRecord struct {
+		MigrationRecord
+		Author string `db:"author"`
+	}
+
+	dbMap := gorp.DbMap{Db: s.Db, Dialect: gorp.SqliteDialect{}}
+	dbMap.AddTableWithNameAndSchema(CustomMigrationRecord{}, "", tableName).SetKeys(false, "Id")
+
+	err := dbMap.CreateTables()
+	c.Assert(err, IsNil)
+
+	_, _, err = PlanMigration(s.Db, "sqlite3", migrations, Up, 1)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
If the migration table already exists with more columns than the
internal MigrationRecord knows then PlanMigration would fail.

With this commit these non fatal errors are silently ignored.