### PR TITLE
Add HttpFileSystemSource support.

### DIFF
--- a/migrate_test.go
+++ b/migrate_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"database/sql"
 	"io/ioutil"
+	"net/http"
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -121,6 +122,22 @@ func (s *SqliteMigrateSuite) TestMigrateIncremental(c *C) {
 func (s *SqliteMigrateSuite) TestFileMigrate(c *C) {
 	migrations := &FileMigrationSource{
 		Dir: "test-migrations",
+	}
+
+	// Executes two migrations
+	n, err := Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+
+	// Has data
+	id, err := s.DbMap.SelectInt("SELECT id FROM people")
+	c.Assert(err, IsNil)
+	c.Assert(id, Equals, int64(1))
+}
+
+func (s *SqliteMigrateSuite) TestHttpFileSystemMigrate(c *C) {
+	migrations := &HttpFileSystemMigrationSource{
+		FileSystem: http.Dir("test-migrations"),
 	}
 
 	// Executes two migrations


### PR DESCRIPTION
I would like to be able to use an `http.FileSystem` (the closest to a virtual filesystem interface standard library has) as a migration source.

The use case is that I use an embedding tool that uses this http.FileSystem as interface.