### PR TITLE
feat: allow only comment

### DIFF
--- a/sqlparse/sqlparse.go
+++ b/sqlparse/sqlparse.go
@@ -129,6 +129,10 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
+		// ignore comment except beginning with '-- +'
+		if strings.HasPrefix(line, "-- ") && !strings.HasPrefix(line, "-- +") {
+			continue
+		}
 
 		// handle any migrate-specific commands
 		if strings.HasPrefix(line, sqlCmdPrefix) {
@@ -179,7 +183,7 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 
 		isLineSeparator := !ignoreSemicolons && len(LineSeparator) > 0 && line == LineSeparator
 
-		if !isLineSeparator {
+		if !isLineSeparator && !strings.HasPrefix(line, "-- +") {
 			if _, err := buf.WriteString(line + "\n"); err != nil {
 				return nil, err
 			}
@@ -219,7 +223,10 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 			See https://github.com/rubenv/sql-migrate for details.`)
 	}
 
-	if len(strings.TrimSpace(buf.String())) > 0 {
+	// allow comment without sql instruction. Example:
+	// -- +migrate Down
+	// -- nothing to downgrade!
+	if len(strings.TrimSpace(buf.String())) > 0 && !strings.HasPrefix(buf.String(), "-- +") {
 		return nil, errNoTerminator()
 	}
 

--- a/sqlparse/sqlparse_test.go
+++ b/sqlparse/sqlparse_test.go
@@ -88,6 +88,13 @@ func (s *SqlParseSuite) TestIntentionallyBadStatements(c *C) {
 	}
 }
 
+func (s *SqlParseSuite) TestJustComment(c *C) {
+	for _, test := range justAComment {
+		_, err := ParseMigration(strings.NewReader(test))
+		c.Assert(err, NotNil)
+	}
+}
+
 func (s *SqlParseSuite) TestCustomTerminator(c *C) {
 	LineSeparator = "GO"
 	defer func() { LineSeparator = "" }()
@@ -356,3 +363,17 @@ GO
 DROP TABLE fancier_post
 GO
 `
+
+// test a comment without sql instruction
+var justAComment = []string{
+	`-- +migrate Up
+CREATE TABLE post (
+    id int NOT NULL,
+    title text,
+    body text,
+    PRIMARY KEY(id)
+)
+
+-- +migrate Down
+-- no migration here
+`}


### PR DESCRIPTION
In previous version of sql-migrate, it was ok to write "-- +migrate Down" with just a comment.
Now, on master, it's not possible anymore.

This PR will allow user to comment a  section without having a sql instruction.
The comments are also ignored properly.

Example:
"
-- +migrate Down
-- no migration here
"