### PR TITLE
Fix panic when migration file removed

### DIFF
--- a/sql-migrate/command_status.go
+++ b/sql-migrate/command_status.go
@@ -83,12 +83,17 @@ func (c *StatusCommand) Run(args []string) int {
 	}
 
 	for _, r := range records {
+		if rows[r.Id] == nil {
+			ui.Warn(fmt.Sprintf("Could not find migration file: %v", r.Id))
+			continue
+		}
+
 		rows[r.Id].Migrated = true
 		rows[r.Id].AppliedAt = r.AppliedAt
 	}
 
 	for _, m := range migrations {
-		if rows[m.Id].Migrated {
+		if rows[m.Id] != nil && rows[m.Id].Migrated {
 			table.Append([]string{
 				m.Id,
 				rows[m.Id].AppliedAt.String(),


### PR DESCRIPTION
When a migration file is removed, command `sql-migrate status` will panic as it couldn't find the relevant file on migration folder. This PR attempts to fix that panic.