### PR TITLE
Fix a race condition in the sql-migrate memory migration struct

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -144,10 +144,13 @@ type MemoryMigrationSource struct {
 var _ MigrationSource = (*MemoryMigrationSource)(nil)
 
 func (m MemoryMigrationSource) FindMigrations() ([]*Migration, error) {
-	// Make sure migrations are sorted
-	sort.Sort(byId(m.Migrations))
-
-	return m.Migrations, nil
+	// Make sure migrations are sorted. In order to make the MemoryMigrationSource safe for
+	// concurrent use we should not mutate it in place. So `FindMigrations` would sort a copy
+	// of the m.Migrations.
+	migrations := make([]*Migration, len(m.Migrations))
+	copy(migrations, m.Migrations)
+	sort.Sort(byId(migrations))
+	return migrations, nil
 }
 
 // A set of migrations loaded from an http.FileServer


### PR DESCRIPTION
Concurrent usage of the `MemoryMigrationSource` was impossible because
it was mutating its `Migrations` property in place. This commit makes
this possible by making sure the `FindMigrations` sorts a copy of the
migrations list instead of the shared one.