### PR TITLE
Adds verbose(`-v`) flag to install command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Using [modl](https://github.com/jmoiron/modl)? Check out [modl-migrate](https://
 To install the library and command line program, use the following:
 
 ```bash
-go get github.com/rubenv/sql-migrate/...
+go -v get github.com/rubenv/sql-migrate/...
 ```
 
 ## Usage


### PR DESCRIPTION
For users not used to `go get` it can look like it is stuck because nothing is printed on the screen for sometime, adding the `-v` display some progress.