### PR TITLE
Allow accepting env vars for config

### DIFF
--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -39,7 +39,7 @@ type Environment struct {
 	SchemaName string `yaml:"schema"`
 }
 
-func ReadConfig() (map[string]*Environment, error) {
+func ReadConfigFromFile() (map[string]*Environment, error) {
 	file, err := ioutil.ReadFile(ConfigFile)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func ReadConfig() (map[string]*Environment, error) {
 }
 
 func GetEnvironment() (*Environment, error) {
-	config, err := ReadConfig()
+	config, err := ReadConfigFromFile()
 	if err != nil {
 		return nil, err
 	}

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -39,7 +39,7 @@ type Environment struct {
 	SchemaName string `yaml:"schema"`
 }
 
-func ReadConfigFromFile() (map[string]*Environment, error) {
+func ReadEnvFromFile() (*Environment, error) {
 	file, err := ioutil.ReadFile(ConfigFile)
 	if err != nil {
 		return nil, err
@@ -51,18 +51,18 @@ func ReadConfigFromFile() (map[string]*Environment, error) {
 		return nil, err
 	}
 
-	return config, nil
-}
-
-func GetEnvironment() (*Environment, error) {
-	config, err := ReadConfigFromFile()
-	if err != nil {
-		return nil, err
-	}
-
 	env := config[ConfigEnvironment]
 	if env == nil {
 		return nil, errors.New("No environment: " + ConfigEnvironment)
+	}
+
+	return env, nil
+}
+
+func GetEnvironment() (*Environment, error) {
+	env, err := ReadEnvFromFile()
+	if err != nil {
+		return nil, err
 	}
 
 	if env.Dialect == "" {


### PR DESCRIPTION
Our company has a use case to provide the environment information through the shell environment instead of from a `dbconfig.yml` file. We have augmented the `sql-migrate` binary's capability to check for a `dbconfig.yml` file before trying to read it in, and if there is no file present, it will be optimistic and try to read from the shell environment. Failing to read from the environment if there is no file will work as it did before with the zero-value checking that happens in the last part of `GetEnvironment`. If these changes are acceptable to introduce to the parent project would like to do so.

Example usage showing that this:
* honors the `dbconfig.yml` if present
* fails in the same way as before this PR if no file nor no shell environment variables are provided
* leverages the shell environment variables if present and the `dbconfig.yml` is not present

```
 $ go install ./...
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:35:57 
 $ date
Fri Nov 16 14:36:00 EST 2018
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:36:00 
 $ ll ~/workspace/go/bin/sql-migrate 
-rwxrwxr-x. 1 quinten quinten 14090392 Nov 16 14:35 /home/quinten/workspace/go/bin/sql-migrate
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:36:15 
 $ ls dbconfig.yml
dbconfig.yml
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:36:39 
 $ ~/workspace/go/bin/sql-migrate status
+-----------------------------+--------------------------------------+
|          MIGRATION          |               APPLIED                |
+-----------------------------+--------------------------------------+
| 20181115113718-qpinit.sql   | 2018-11-15 16:40:57.640617 +0000 UTC |
| 20181116142709-testtest.sql | 2018-11-16 19:29:19.577488 +0000 UTC |
+-----------------------------+--------------------------------------+
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:37:16 
 $ mv dbconfig.yml dev/
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 0 14:37:21 
 $ ~/workspace/go/bin/sql-migrate status
Could not parse config: No dialect specified
~/w/g/s/g/r/sql-migrate * (allow-accepting-env-vars-over-file) (1ef8a56) quinten@workdora 1 14:37:23 
 $ envinjector -file-name ~/dev/env/sqlmigrate.yml ~/workspace/go/bin/sql-migrate status
+-----------------------------+--------------------------------------+
|          MIGRATION          |               APPLIED                |
+-----------------------------+--------------------------------------+
| 20181115113718-qpinit.sql   | 2018-11-15 16:40:57.640617 +0000 UTC |
| 20181116142709-testtest.sql | 2018-11-16 19:29:19.577488 +0000 UTC |
+-----------------------------+--------------------------------------+
```