### PR TITLE
Fix inconsistent naming of config files #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Usage: sql-migrate up [options] ...
 
 Options:
 
-  -config=config.yml   Configuration file to use.
-  -env="development"   Environment.
-  -limit=0             Limit the number of migrations (0 = unlimited).
-  -dryrun              Don't apply migrations, just print them.
+  -config=dbconfig.yml   Configuration file to use.
+  -env="development"     Environment.
+  -limit=0               Limit the number of migrations (0 = unlimited).
+  -dryrun                Don't apply migrations, just print them.
 ```
 
 The `new` command creates a new empty migration template using the following pattern `<current time>-<name>.sql`.


### PR DESCRIPTION
fixes #107 
The current readme is using both dbconfig.yml and config.yml.
This makes the user unsure about what is best practice naming the config file.