### PR TITLE
fix skip message

### DIFF
--- a/sql-migrate/command_skip.go
+++ b/sql-migrate/command_skip.go
@@ -73,11 +73,12 @@ func SkipMigrations(dir migrate.MigrationDirection, dryrun bool, limit int) erro
 		return fmt.Errorf("Migration failed: %s", err)
 	}
 
-	ui.Output("Skipped 1 migration")
-
-	if n == 1 {
+	switch n {
+	case 0:
+		ui.Output("All migrations have already been applied")
+	case 1:
 		ui.Output("Skipped 1 migration")
-	} else {
+	default:
 		ui.Output(fmt.Sprintf("Skipped %d migrations", n))
 	}
 


### PR DESCRIPTION
Fixed an issue where skip messages were not displayed correctly.

before fixing
```
// n = 0
$ ./sql-migrate skip
Skipped 1 migration
Skipped 0 migrations

// n = 1
$ ./sql-migrate skip
Skipped 1 migration
Skipped 1 migration

// n > 2
$ ./sql-migrate skip
Skipped 1 migration
Skipped n migrations
```

after fixing
```
// n = 0
$ ./sql-migrate skip
All migrations have already been applied

// n = 1
$ ./sql-migrate skip
Skipped 1 migrations

// n > 2
$ ./sql-migrate skip
Skipped n migrations
```