### PR TITLE
Print error message on redo command

### DIFF
--- a/sql-migrate/command_redo.go
+++ b/sql-migrate/command_redo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rubenv/sql-migrate"
+	migrate "github.com/rubenv/sql-migrate"
 )
 
 type RedoCommand struct {
@@ -60,7 +60,10 @@ func (c *RedoCommand) Run(args []string) int {
 	}
 
 	migrations, _, err := migrate.PlanMigration(db, dialect, source, migrate.Down, 1)
-	if len(migrations) == 0 {
+	if err != nil {
+		ui.Error(fmt.Sprintf("Migration (redo) failed: %v", err))
+		return 1
+	} else if len(migrations) == 0 {
 		ui.Output("Nothing to do!")
 		return 0
 	}


### PR DESCRIPTION
When you want to reapply a migration and there is an error, sql-migrate shows:
`Nothing to do!`
Which is not true in the case of having errors. Now, in order to know which error do you have, you need to perform sql-migrate down and then up again.

The proposal is to print the error and exit the program