### PR TITLE
Add type MigrationSet to allow concurrent usage of sql-migrate

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -25,8 +25,30 @@ const (
 	Down
 )
 
-var tableName = "gorp_migrations"
-var schemaName = ""
+// MigrationSet provides database parameters for a migration execution
+type MigrationSet struct {
+	// Name of the table used to store migration info.
+	tableName string
+	// Name of a schema that the migration table be referenced.
+	schemaName string
+}
+
+// NewMigrationSet returns a parametrized Migration object
+func NewMigrationSet(schemaName string, tableName string) MigrationSet {
+	if tableName == "" {
+		tableName = "gorp_migrations"
+	}
+	return MigrationSet{
+		tableName:  tableName,
+		schemaName: schemaName,
+	}
+}
+
+var migSet = MigrationSet{
+	tableName:  "gorp_migrations",
+	schemaName: "",
+}
+
 var numberPrefixRegex = regexp.MustCompile(`^(\d+).*$`)
 
 // PlanError happens where no migration plan could be created between the sets
@@ -73,14 +95,14 @@ func (e *TxError) Error() string {
 // Should be called before any other call such as (Exec, ExecMax, ...).
 func SetTable(name string) {
 	if name != "" {
-		tableName = name
+		migSet.tableName = name
 	}
 }
 
 // SetSchema sets the name of a schema that the migration table be referenced.
 func SetSchema(name string) {
 	if name != "" {
-		schemaName = name
+		migSet.schemaName = name
 	}
 }
 
@@ -366,13 +388,23 @@ func Exec(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection)
 	return ExecMax(db, dialect, m, dir, 0)
 }
 
+// Returns the number of applied migrations.
+func (ms MigrationSet) Exec(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection) (int, error) {
+	return ms.ExecMax(db, dialect, m, dir, 0)
+}
+
 // Execute a set of migrations
 //
 // Will apply at most `max` migrations. Pass 0 for no limit (or use Exec).
 //
 // Returns the number of applied migrations.
 func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int) (int, error) {
-	migrations, dbMap, err := PlanMigration(db, dialect, m, dir, max)
+	return migSet.ExecMax(db, dialect, m, dir, max)
+}
+
+// Returns the number of applied migrations.
+func (ms MigrationSet) ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int) (int, error) {
+	migrations, dbMap, err := ms.PlanMigration(db, dialect, m, dir, max)
 	if err != nil {
 		return 0, err
 	}
@@ -443,7 +475,11 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 
 // Plan a migration.
 func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int) ([]*PlannedMigration, *gorp.DbMap, error) {
-	dbMap, err := getMigrationDbMap(db, dialect)
+	return migSet.PlanMigration(db, dialect, m, dir, max)
+}
+
+func (ms MigrationSet) PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int) ([]*PlannedMigration, *gorp.DbMap, error) {
+	dbMap, err := ms.getMigrationDbMap(db, dialect)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -454,7 +490,7 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	}
 
 	var migrationRecords []MigrationRecord
-	_, err = dbMap.Select(&migrationRecords, fmt.Sprintf("SELECT * FROM %s", dbMap.Dialect.QuotedTableForQuery(schemaName, tableName)))
+	_, err = dbMap.Select(&migrationRecords, fmt.Sprintf("SELECT * FROM %s", dbMap.Dialect.QuotedTableForQuery(ms.schemaName, ms.tableName)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -621,13 +657,17 @@ func ToCatchup(migrations, existingMigrations []*Migration, lastRun *Migration) 
 }
 
 func GetMigrationRecords(db *sql.DB, dialect string) ([]*MigrationRecord, error) {
-	dbMap, err := getMigrationDbMap(db, dialect)
+	return migSet.GetMigrationRecords(db, dialect)
+}
+
+func (ms MigrationSet) GetMigrationRecords(db *sql.DB, dialect string) ([]*MigrationRecord, error) {
+	dbMap, err := ms.getMigrationDbMap(db, dialect)
 	if err != nil {
 		return nil, err
 	}
 
 	var records []*MigrationRecord
-	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id ASC", dbMap.Dialect.QuotedTableForQuery(schemaName, tableName))
+	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id ASC", dbMap.Dialect.QuotedTableForQuery(ms.schemaName, ms.tableName))
 	_, err = dbMap.Select(&records, query)
 	if err != nil {
 		return nil, err
@@ -636,7 +676,7 @@ func GetMigrationRecords(db *sql.DB, dialect string) ([]*MigrationRecord, error)
 	return records, nil
 }
 
-func getMigrationDbMap(db *sql.DB, dialect string) (*gorp.DbMap, error) {
+func (ms MigrationSet) getMigrationDbMap(db *sql.DB, dialect string) (*gorp.DbMap, error) {
 	d, ok := MigrationDialects[dialect]
 	if !ok {
 		return nil, fmt.Errorf("Unknown dialect: %s", dialect)
@@ -664,7 +704,7 @@ Check https://github.com/go-sql-driver/mysql#parsetime for more info.`)
 
 	// Create migration database map
 	dbMap := &gorp.DbMap{Db: db, Dialect: d}
-	dbMap.AddTableWithNameAndSchema(MigrationRecord{}, schemaName, tableName).SetKeys(false, "Id")
+	dbMap.AddTableWithNameAndSchema(MigrationRecord{}, ms.schemaName, ms.tableName).SetKeys(false, "Id")
 	//dbMap.TraceOn("", log.New(os.Stdout, "migrate: ", log.Lmicroseconds))
 
 	err := dbMap.CreateTablesIfNotExists()

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -557,3 +557,24 @@ func (s *SqliteMigrateSuite) TestExecWithUnknownMigrationInDatabase(c *C) {
 	_, err = s.DbMap.Exec("SELECT age FROM people")
 	c.Assert(err, NotNil)
 }
+
+func (s *SqliteMigrateSuite) TestRunMigrationObj(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: sqliteMigrations[:1],
+	}
+
+	ms := NewMigrationSet("", "")
+	// Executes one migration
+	n, err := ms.Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+
+	// Can use table now
+	_, err = s.DbMap.Exec("SELECT * FROM people")
+	c.Assert(err, IsNil)
+
+	// Shouldn't apply migration again
+	n, err = ms.Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 0)
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -558,12 +558,12 @@ func (s *SqliteMigrateSuite) TestExecWithUnknownMigrationInDatabase(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *SqliteMigrateSuite) TestRunMigrationObj(c *C) {
+func (s *SqliteMigrateSuite) TestRunMigrationObjDefaultTable(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: sqliteMigrations[:1],
 	}
 
-	ms := NewMigrationSet("", "")
+	ms := MigrationSet{}
 	// Executes one migration
 	n, err := ms.Exec(s.Db, "sqlite3", migrations, Up)
 	c.Assert(err, IsNil)
@@ -571,6 +571,35 @@ func (s *SqliteMigrateSuite) TestRunMigrationObj(c *C) {
 
 	// Can use table now
 	_, err = s.DbMap.Exec("SELECT * FROM people")
+	c.Assert(err, IsNil)
+
+	// Uses default tableName
+	_, err = s.DbMap.Exec("SELECT * FROM gorp_migrations")
+	c.Assert(err, IsNil)
+
+	// Shouldn't apply migration again
+	n, err = ms.Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 0)
+}
+
+func (s *SqliteMigrateSuite) TestRunMigrationObjOtherTable(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: sqliteMigrations[:1],
+	}
+
+	ms := MigrationSet{TableName: "other_migrations"}
+	// Executes one migration
+	n, err := ms.Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+
+	// Can use table now
+	_, err = s.DbMap.Exec("SELECT * FROM people")
+	c.Assert(err, IsNil)
+
+	// Uses default tableName
+	_, err = s.DbMap.Exec("SELECT * FROM other_migrations")
 	c.Assert(err, IsNil)
 
 	// Shouldn't apply migration again


### PR DESCRIPTION
Usage of global variable in migrate package make difficult the concurrent usage of sql-migrate on two (or more) databases/schema.

This PR introduce a MigrationSet type that provide a way to instanciate sql-migrate with different parameters for databases.

To ensure backward compatibility the global variables (tableName and schemaName) are replaced by a MigrationSet instance and functions without receiver call their MigrationSet counterpart on this instance). 