### PR TITLE
Add ability to skip unknown migrations in database

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -35,7 +35,7 @@ type MigrationSet struct {
 	// IgnoreUnknown skips the check to see if there is a migration
 	// ran in the database that is not in MigrationSource.
 	//
-	// This should be used sparingly as it is removing a saftey check.
+	// This should be used sparingly as it is removing a safety check.
 	IgnoreUnknown bool
 }
 

--- a/migrate.go
+++ b/migrate.go
@@ -33,7 +33,9 @@ type MigrationSet struct {
 	// SchemaName schema that the migration table be referenced.
 	SchemaName string
 	// IgnoreUnknown skips the check to see if there is a migration
-	// ran in the database that is not in MigrationSource
+	// ran in the database that is not in MigrationSource.
+	//
+	// This should be used sparingly as it is removing a saftey check.
 	IgnoreUnknown bool
 }
 
@@ -106,6 +108,8 @@ func SetSchema(name string) {
 
 // SetIgnoreUnknown sets the flag that skips database check to see if there is a
 // migration in the database that is not in migration source.
+//
+// This should be used sparingly as it is removing a saftey check.
 func SetIgnoreUnknown(v bool) {
 	migSet.IgnoreUnknown = v
 }

--- a/migrate.go
+++ b/migrate.go
@@ -109,7 +109,7 @@ func SetSchema(name string) {
 // SetIgnoreUnknown sets the flag that skips database check to see if there is a
 // migration in the database that is not in migration source.
 //
-// This should be used sparingly as it is removing a saftey check.
+// This should be used sparingly as it is removing a safety check.
 func SetIgnoreUnknown(v bool) {
 	migSet.IgnoreUnknown = v
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -516,6 +516,47 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithUnknownDatabaseMigrationApplie
 	c.Assert(err, FitsTypeOf, &PlanError{})
 }
 
+func (s *SqliteMigrateSuite) TestPlanMigrationWithIgnoredUnknownDatabaseMigrationApplied(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: []*Migration{
+			&Migration{
+				Id:   "1_create_table.sql",
+				Up:   []string{"CREATE TABLE people (id int)"},
+				Down: []string{"DROP TABLE people"},
+			},
+			&Migration{
+				Id:   "2_alter_table.sql",
+				Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+				Down: []string{"SELECT 0"}, // Not really supported
+			},
+			&Migration{
+				Id:   "10_add_last_name.sql",
+				Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
+				Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+			},
+		},
+	}
+	SetIgnoreUnknown(true)
+	n, err := Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 3)
+
+	// Note that migration 10_add_last_name.sql is missing from the new migrations source
+	// so it is considered an "unknown" migration for the planner.
+	migrations.Migrations = append(migrations.Migrations[:2], &Migration{
+		Id:   "10_add_middle_name.sql",
+		Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
+		Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+	})
+
+	_, _, err = PlanMigration(s.Db, "sqlite3", migrations, Up, 0)
+	c.Assert(err, IsNil)
+
+	_, _, err = PlanMigration(s.Db, "sqlite3", migrations, Down, 0)
+	c.Assert(err, IsNil)
+	SetIgnoreUnknown(false) // Make sure we are not breaking other tests as this is globaly set
+}
+
 // TestExecWithUnknownMigrationInDatabase makes sure that problems found with planning the
 // migrations are propagated and returned by Exec.
 func (s *SqliteMigrateSuite) TestExecWithUnknownMigrationInDatabase(c *C) {


### PR DESCRIPTION
I know this seems like a very strange request. But as it isn't a backwards breaking and I may not be the only one, I figure why not open a PR.

Scenario:

In a microservice type situation where each service maintains its own schema (yes only schema, not DB), there is a case where this pops up.

In Postgres, I have a `public` schema in each DB and a `service_name` schema that is owned by a particular service. Multiple services can share the same DB. That way a service can read (not write) to other services data. But all the services in the same DB will use the same `public` schema.

If service A has newer migrations for the `public` schema and I want to deploy a version of service B that doesn't have the new migrations, if service A is applied first then service B, Service B would complain that there is a migration in the database that is not in the known migration source.

I am consuming `sql-migrate` as a package and will be writing my own MigrationSource as we have a pretty specific structure to follow (many microservices in a single mono repository). This is the only that has me stuck. I would really appreciate not having to maintain my own migrator (a fork of this), but completely understand if this is too much of an edge case to merge in and maintain.