### PR TITLE
fix: Quote `id` column as it described in dialect definition

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -707,7 +707,7 @@ func (ms MigrationSet) GetMigrationRecords(db *sql.DB, dialect string) ([]*Migra
 	}
 
 	var records []*MigrationRecord
-	query := fmt.Sprintf("SELECT * FROM %s ORDER BY id ASC", dbMap.Dialect.QuotedTableForQuery(ms.SchemaName, ms.getTableName()))
+	query := fmt.Sprintf("SELECT * FROM %s ORDER BY %s ASC", dbMap.Dialect.QuotedTableForQuery(ms.SchemaName, ms.getTableName()), dbMap.Dialect.QuoteField("id"))
 	_, err = dbMap.Select(&records, query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using `sql-migrate` with Snowflake I got the problem with the execution of the `"SELECT * FROM %s ORDER BY id ASC"`. The quoting of the `ID` column solving the problem.