### PR TITLE
Adds "ignoreunknown" flag to "up" cli command

### DIFF
--- a/sql-migrate/command_up.go
+++ b/sql-migrate/command_up.go
@@ -22,6 +22,7 @@ Options:
   -env="development"     Environment.
   -limit=0               Limit the number of migrations (0 = unlimited).
   -dryrun                Don't apply migrations, just print them.
+  -ignoreunknown         Skips the check to see if there is a migration ran in the database that is not in MigrationSource, this should be used sparingly as it is removing a safety check.
 
 `
 	return strings.TrimSpace(helpText)
@@ -34,12 +35,15 @@ func (c *UpCommand) Synopsis() string {
 func (c *UpCommand) Run(args []string) int {
 	var limit int
 	var dryrun bool
+	var ignoreUnknown bool
 
 	cmdFlags := flag.NewFlagSet("up", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 0, "Max number of migrations to apply.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
+	cmdFlags.BoolVar(&ignoreUnknown, "ignoreunknown", false, "Skips the check to see if there is a migration ran in the database that is not in MigrationSource, this should be used sparingly as it is removing a safety check.")
 	ConfigFlags(cmdFlags)
+	migrate.SetIgnoreUnknown(ignoreUnknown)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1

--- a/sql-migrate/command_up.go
+++ b/sql-migrate/command_up.go
@@ -22,7 +22,7 @@ Options:
   -env="development"     Environment.
   -limit=0               Limit the number of migrations (0 = unlimited).
   -dryrun                Don't apply migrations, just print them.
-  -ignoreunknown         Skips the check to see if there is a migration ran in the database that is not in MigrationSource, this should be used sparingly as it is removing a safety check.
+  -ignoreunknown=false   Skips the check to see if there is a migration ran in the database that is not in MigrationSource, this should be used sparingly as it is removing a safety check.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Thought it could be helpful to add the "ignoreunknown" option as a flag on the CLI.
I only added it to the `up` command, but for consistency, we could also add it to other commands like `down`.

```
> sql-migrate up --help
Usage: sql-migrate up [options] ...

  Migrates the database to the most recent version available.

Options:

  -config=dbconfig.yml   Configuration file to use.
  -env="development"     Environment.
  -limit=0               Limit the number of migrations (0 = unlimited).
  -dryrun                Don't apply migrations, just print them.
  -ignoreunknown=false   Skips the check to see if there is a migration ran in the database that is not in MigrationSource, this should be used sparingly as it is removing a safety check.
```

The use case is that when I do a deployment for my service the first thing I do is running the DB migration (`sql-migrate up`), but, if I want to rollback the deployment (or redeploy the previous version for that matter) the `sql-migration up` would throw an error in case a new migration existed. The flag would address this case .