### PR TITLE
Fix Windows filepath separator bug

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -276,7 +275,7 @@ func findMigrations(dir http.FileSystem, root string) ([]*Migration, error) {
 }
 
 func migrationFromFile(dir http.FileSystem, root string, info os.FileInfo) (*Migration, error) {
-	path := filepath.Join(root, info.Name())
+	path := path.Join(root, info.Name())
 	file, err := dir.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("Error while opening %s: %s", info.Name(), err)


### PR DESCRIPTION
The implementation uses the FileSystem of the http package which uses "/" as a separator in paths regardless of the operating system. However, the `filepath.join`-method creates a path using the system-specific separator ("\\" for Windows, see [documentation](https://golang.org/pkg/path/filepath/#Join)) which results in a `http: invalid character in file path`-error in the `migrationFromFile`-method. Using the `path.join`-method instead resolves this issue.