### PR TITLE
Add disable option to avoid creating migration table on getting db map

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -37,6 +37,8 @@ type MigrationSet struct {
 	//
 	// This should be used sparingly as it is removing a safety check.
 	IgnoreUnknown bool
+	// DisableCreateTable disable the creation of the migration table
+	DisableCreateTable bool
 }
 
 var migSet = MigrationSet{}
@@ -104,6 +106,11 @@ func SetSchema(name string) {
 	if name != "" {
 		migSet.SchemaName = name
 	}
+}
+
+// SetDisableCreateTable sets the boolean to disable the creation of the migration table
+func SetDisableCreateTable(disable bool) {
+	migSet.DisableCreateTable = disable
 }
 
 // SetIgnoreUnknown sets the flag that skips database check to see if there is a
@@ -750,6 +757,10 @@ Check https://github.com/go-sql-driver/mysql#parsetime for more info.`)
 
 	if dialect == "oci8" || dialect == "godror" {
 		table.ColMap("Id").SetMaxSize(4000)
+	}
+
+	if migSet.DisableCreateTable {
+		return dbMap, nil
 	}
 
 	err := dbMap.CreateTablesIfNotExists()

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -648,3 +648,20 @@ func (s *SqliteMigrateSuite) TestRunMigrationObjOtherTable(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 0)
 }
+
+func (s *SqliteMigrateSuite) TestSetDisableCreateTable(c *C) {
+	c.Assert(migSet.DisableCreateTable, Equals, false)
+
+	SetDisableCreateTable(true)
+	c.Assert(migSet.DisableCreateTable, Equals, true)
+
+	SetDisableCreateTable(false)
+	c.Assert(migSet.DisableCreateTable, Equals, false)
+}
+
+func (s *SqliteMigrateSuite) TestGetMigrationDbMapWithDisableCreateTable(c *C) {
+	SetDisableCreateTable(false)
+
+	_, err := migSet.getMigrationDbMap(s.Db, "postgres")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
We want to use your package as a data migration tool, the problem is that our postgresql user has only INSERT, UPDATE and DELETE right. Another team, is responsible database schema and won't handle the data queries.

The only issue with the package is the creation of the migration table before any migration.

So I added a switch to avoid the migration table querie before executing the migration.