### PR TITLE
Open and parse files lazily

### DIFF
--- a/migrate_test.go
+++ b/migrate_test.go
@@ -11,15 +11,19 @@ import (
 )
 
 var sqliteMigrations = []*Migration{
-	&Migration{
-		Id:   "123",
-		Up:   []string{"CREATE TABLE people (id int)"},
-		Down: []string{"DROP TABLE people"},
+	{
+		Id: "123",
+		data: &MigrationData{
+			Up:   []string{"CREATE TABLE people (id int)"},
+			Down: []string{"DROP TABLE people"},
+		},
 	},
-	&Migration{
-		Id:   "124",
-		Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
-		Down: []string{"SELECT 0"}, // Not really supported
+	{
+		Id: "124",
+		data: &MigrationData{
+			Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+			Down: []string{"SELECT 0"}, // Not really supported
+		},
 	},
 }
 
@@ -281,10 +285,12 @@ func (s *SqliteMigrateSuite) TestMigrateTransaction(c *C) {
 		Migrations: []*Migration{
 			sqliteMigrations[0],
 			sqliteMigrations[1],
-			&Migration{
-				Id:   "125",
-				Up:   []string{"INSERT INTO people (id, first_name) VALUES (1, 'Test')", "SELECT fail"},
-				Down: []string{}, // Not important here
+			{
+				Id: "125",
+				data: &MigrationData{
+					Up:   []string{"INSERT INTO people (id, first_name) VALUES (1, 'Test')", "SELECT fail"},
+					Down: []string{}, // Not important here
+				},
 			},
 		},
 	}
@@ -303,20 +309,26 @@ func (s *SqliteMigrateSuite) TestMigrateTransaction(c *C) {
 func (s *SqliteMigrateSuite) TestPlanMigration(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: []*Migration{
-			&Migration{
-				Id:   "1_create_table.sql",
-				Up:   []string{"CREATE TABLE people (id int)"},
-				Down: []string{"DROP TABLE people"},
+			{
+				Id: "1_create_table.sql",
+				data: &MigrationData{
+					Up:   []string{"CREATE TABLE people (id int)"},
+					Down: []string{"DROP TABLE people"},
+				},
 			},
-			&Migration{
-				Id:   "2_alter_table.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
-				Down: []string{"SELECT 0"}, // Not really supported
+			{
+				Id: "2_alter_table.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+					Down: []string{"SELECT 0"}, // Not really supported
+				},
 			},
-			&Migration{
-				Id:   "10_add_last_name.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
-				Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+			{
+				Id: "10_add_last_name.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
+					Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+				},
 			},
 		},
 	}
@@ -325,9 +337,11 @@ func (s *SqliteMigrateSuite) TestPlanMigration(c *C) {
 	c.Assert(n, Equals, 3)
 
 	migrations.Migrations = append(migrations.Migrations, &Migration{
-		Id:   "11_add_middle_name.sql",
-		Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
-		Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		Id: "11_add_middle_name.sql",
+		data: &MigrationData{
+			Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
+			Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		},
 	})
 
 	plannedMigrations, _, err := PlanMigration(s.Db, "sqlite3", migrations, Up, 0)
@@ -346,20 +360,26 @@ func (s *SqliteMigrateSuite) TestPlanMigration(c *C) {
 func (s *SqliteMigrateSuite) TestSkipMigration(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: []*Migration{
-			&Migration{
-				Id:   "1_create_table.sql",
-				Up:   []string{"CREATE TABLE people (id int)"},
-				Down: []string{"DROP TABLE people"},
+			{
+				Id: "1_create_table.sql",
+				data: &MigrationData{
+					Up:   []string{"CREATE TABLE people (id int)"},
+					Down: []string{"DROP TABLE people"},
+				},
 			},
-			&Migration{
-				Id:   "2_alter_table.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
-				Down: []string{"SELECT 0"}, // Not really supported
+			{
+				Id: "2_alter_table.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+					Down: []string{"SELECT 0"}, // Not really supported
+				},
 			},
-			&Migration{
-				Id:   "10_add_last_name.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
-				Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+			{
+				Id: "10_add_last_name.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
+					Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+				},
 			},
 		},
 	}
@@ -386,15 +406,19 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithHoles(c *C) {
 	down := "SELECT 1"
 	migrations := &MemoryMigrationSource{
 		Migrations: []*Migration{
-			&Migration{
-				Id:   "1",
-				Up:   []string{up},
-				Down: []string{down},
+			{
+				Id: "1",
+				data: &MigrationData{
+					Up:   []string{up},
+					Down: []string{down},
+				},
 			},
-			&Migration{
-				Id:   "3",
-				Up:   []string{up},
-				Down: []string{down},
+			{
+				Id: "3",
+				data: &MigrationData{
+					Up:   []string{up},
+					Down: []string{down},
+				},
 			},
 		},
 	}
@@ -403,21 +427,27 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithHoles(c *C) {
 	c.Assert(n, Equals, 2)
 
 	migrations.Migrations = append(migrations.Migrations, &Migration{
-		Id:   "2",
-		Up:   []string{up},
-		Down: []string{down},
+		Id: "2",
+		data: &MigrationData{
+			Up:   []string{up},
+			Down: []string{down},
+		},
 	})
 
 	migrations.Migrations = append(migrations.Migrations, &Migration{
-		Id:   "4",
-		Up:   []string{up},
-		Down: []string{down},
+		Id: "4",
+		data: &MigrationData{
+			Up:   []string{up},
+			Down: []string{down},
+		},
 	})
 
 	migrations.Migrations = append(migrations.Migrations, &Migration{
-		Id:   "5",
-		Up:   []string{up},
-		Down: []string{down},
+		Id: "5",
+		data: &MigrationData{
+			Up:   []string{up},
+			Down: []string{down},
+		},
 	})
 
 	// apply all the missing migrations
@@ -476,20 +506,26 @@ func (s *SqliteMigrateSuite) TestLess(c *C) {
 func (s *SqliteMigrateSuite) TestPlanMigrationWithUnknownDatabaseMigrationApplied(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: []*Migration{
-			&Migration{
-				Id:   "1_create_table.sql",
-				Up:   []string{"CREATE TABLE people (id int)"},
-				Down: []string{"DROP TABLE people"},
+			{
+				Id: "1_create_table.sql",
+				data: &MigrationData{
+					Up:   []string{"CREATE TABLE people (id int)"},
+					Down: []string{"DROP TABLE people"},
+				},
 			},
-			&Migration{
-				Id:   "2_alter_table.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
-				Down: []string{"SELECT 0"}, // Not really supported
+			{
+				Id: "2_alter_table.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+					Down: []string{"SELECT 0"}, // Not really supported
+				},
 			},
-			&Migration{
-				Id:   "10_add_last_name.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
-				Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+			{
+				Id: "10_add_last_name.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
+					Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+				},
 			},
 		},
 	}
@@ -500,9 +536,11 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithUnknownDatabaseMigrationApplie
 	// Note that migration 10_add_last_name.sql is missing from the new migrations source
 	// so it is considered an "unknown" migration for the planner.
 	migrations.Migrations = append(migrations.Migrations[:2], &Migration{
-		Id:   "10_add_middle_name.sql",
-		Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
-		Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		Id: "10_add_middle_name.sql",
+		data: &MigrationData{
+			Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
+			Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		},
 	})
 
 	_, _, err = PlanMigration(s.Db, "sqlite3", migrations, Up, 0)
@@ -519,20 +557,26 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithUnknownDatabaseMigrationApplie
 func (s *SqliteMigrateSuite) TestPlanMigrationWithIgnoredUnknownDatabaseMigrationApplied(c *C) {
 	migrations := &MemoryMigrationSource{
 		Migrations: []*Migration{
-			&Migration{
-				Id:   "1_create_table.sql",
-				Up:   []string{"CREATE TABLE people (id int)"},
-				Down: []string{"DROP TABLE people"},
+			{
+				Id: "1_create_table.sql",
+				data: &MigrationData{
+					Up:   []string{"CREATE TABLE people (id int)"},
+					Down: []string{"DROP TABLE people"},
+				},
 			},
-			&Migration{
-				Id:   "2_alter_table.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
-				Down: []string{"SELECT 0"}, // Not really supported
+			{
+				Id: "2_alter_table.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN first_name text"},
+					Down: []string{"SELECT 0"}, // Not really supported
+				},
 			},
-			&Migration{
-				Id:   "10_add_last_name.sql",
-				Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
-				Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+			{
+				Id: "10_add_last_name.sql",
+				data: &MigrationData{
+					Up:   []string{"ALTER TABLE people ADD COLUMN last_name text"},
+					Down: []string{"ALTER TABLE people DROP COLUMN last_name"},
+				},
 			},
 		},
 	}
@@ -544,9 +588,11 @@ func (s *SqliteMigrateSuite) TestPlanMigrationWithIgnoredUnknownDatabaseMigratio
 	// Note that migration 10_add_last_name.sql is missing from the new migrations source
 	// so it is considered an "unknown" migration for the planner.
 	migrations.Migrations = append(migrations.Migrations[:2], &Migration{
-		Id:   "10_add_middle_name.sql",
-		Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
-		Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		Id: "10_add_middle_name.sql",
+		data: &MigrationData{
+			Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
+			Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		},
 	})
 
 	_, _, err = PlanMigration(s.Db, "sqlite3", migrations, Up, 0)
@@ -571,15 +617,19 @@ func (s *SqliteMigrateSuite) TestExecWithUnknownMigrationInDatabase(c *C) {
 
 	// Then create a new migration source with one of the migrations missing
 	var newSqliteMigrations = []*Migration{
-		&Migration{
-			Id:   "124_other",
-			Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
-			Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+		{
+			Id: "124_other",
+			data: &MigrationData{
+				Up:   []string{"ALTER TABLE people ADD COLUMN middle_name text"},
+				Down: []string{"ALTER TABLE people DROP COLUMN middle_name"},
+			},
 		},
-		&Migration{
-			Id:   "125",
-			Up:   []string{"ALTER TABLE people ADD COLUMN age int"},
-			Down: []string{"ALTER TABLE people DROP COLUMN age"},
+		{
+			Id: "125",
+			data: &MigrationData{
+				Up:   []string{"ALTER TABLE people ADD COLUMN age int"},
+				Down: []string{"ALTER TABLE people DROP COLUMN age"},
+			},
 		},
 	}
 	migrations = &MemoryMigrationSource{

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,8 +1,9 @@
 package migrate
 
 import (
-	. "gopkg.in/check.v1"
 	"sort"
+
+	. "gopkg.in/check.v1"
 )
 
 type SortSuite struct{}
@@ -11,14 +12,14 @@ var _ = Suite(&SortSuite{})
 
 func (s *SortSuite) TestSortMigrations(c *C) {
 	var migrations = byId([]*Migration{
-		&Migration{Id: "10_abc", Up: nil, Down: nil},
-		&Migration{Id: "120_cde", Up: nil, Down: nil},
-		&Migration{Id: "1_abc", Up: nil, Down: nil},
-		&Migration{Id: "efg", Up: nil, Down: nil},
-		&Migration{Id: "2_cde", Up: nil, Down: nil},
-		&Migration{Id: "35_cde", Up: nil, Down: nil},
-		&Migration{Id: "3_efg", Up: nil, Down: nil},
-		&Migration{Id: "4_abc", Up: nil, Down: nil},
+		{Id: "10_abc"},
+		{Id: "120_cde"},
+		{Id: "1_abc"},
+		{Id: "efg"},
+		{Id: "2_cde"},
+		{Id: "35_cde"},
+		{Id: "3_efg"},
+		{Id: "4_abc"},
 	})
 
 	sort.Sort(migrations)

--- a/sql-migrate/command_common.go
+++ b/sql-migrate/command_common.go
@@ -49,12 +49,12 @@ func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int) err
 func PrintMigration(m *migrate.PlannedMigration, dir migrate.MigrationDirection) {
 	if dir == migrate.Up {
 		ui.Output(fmt.Sprintf("==> Would apply migration %s (up)", m.Id))
-		for _, q := range m.Up {
+		for _, q := range m.Queries {
 			ui.Output(q)
 		}
 	} else if dir == migrate.Down {
 		ui.Output(fmt.Sprintf("==> Would apply migration %s (down)", m.Id))
-		for _, q := range m.Down {
+		for _, q := range m.Queries {
 			ui.Output(q)
 		}
 	} else {

--- a/toapply_test.go
+++ b/toapply_test.go
@@ -1,14 +1,15 @@
 package migrate
 
 import (
-	. "gopkg.in/check.v1"
 	"sort"
+
+	. "gopkg.in/check.v1"
 )
 
 var toapplyMigrations = []*Migration{
-	&Migration{Id: "abc", Up: nil, Down: nil},
-	&Migration{Id: "cde", Up: nil, Down: nil},
-	&Migration{Id: "efg", Up: nil, Down: nil},
+	{Id: "abc"},
+	{Id: "cde"},
+	{Id: "efg"},
 }
 
 type ToApplyMigrateSuite struct {
@@ -79,11 +80,11 @@ func (s *ToApplyMigrateSuite) TestDownAll(c *C) {
 
 func (s *ToApplyMigrateSuite) TestAlphaNumericMigrations(c *C) {
 	var migrations = byId([]*Migration{
-		&Migration{Id: "10_abc", Up: nil, Down: nil},
-		&Migration{Id: "1_abc", Up: nil, Down: nil},
-		&Migration{Id: "efg", Up: nil, Down: nil},
-		&Migration{Id: "2_cde", Up: nil, Down: nil},
-		&Migration{Id: "35_cde", Up: nil, Down: nil},
+		{Id: "10_abc"},
+		{Id: "1_abc"},
+		{Id: "efg"},
+		{Id: "2_cde"},
+		{Id: "35_cde"},
 	})
 
 	sort.Sort(migrations)


### PR DESCRIPTION
## What I did
Current implementation always parse all of sql files, so may require a lot of time and memory if there are too many files or too big files in directory. But, in most of cases, we only need to parse 1~3 files because sort `byId` does not need content of files, it needs only the name of files.
So, I think it is better to parse sql files only when we need content of files.

Some migration sources are not supported to open/parse lazily in this PR.
`HttpFileSystemMigrationSource`,`FileMigrationSource` and `EmbedFileSystemMigrationSource` are supported, `MemoryMigrationSource`,`AssetMigrationSource` and `PackrBox` are not supported.

I don't think that's a problem because I guess most users don't use the latter migration sources.

ref: https://github.com/rubenv/sql-migrate/issues/203

## How did I test?
I checked that PR passed all of the CI tests.
And, I checked that migration files is never parsed before the program needs the content of  files as below.
Before executing command, I removed semicolons from `1_initial.sql` to make it invalid format.


before PR
```
~/g/s/g/sql-migrate ❯❯❯ ./test-integration/sqlite.sh                                                                          ✘ 1 
+ ./my-sql-migrate status -config=test-integration/dbconfig.yml -env sqlite
Error while parsing 1_initial.sql: Error parsing migration (1_initial.sql): ERROR: The last statement must be ended by a semicolon or '-- +migrate StatementEnd' marker.
			See https://github.com/rubenv/sql-migrate for details.
```


after PR
```
~/g/s/g/sql-migrate ❯❯❯ ./test-integration/sqlite.sh
+ ./my-sql-migrate status -config=test-integration/dbconfig.yml -env sqlite
+---------------+----------------------------------------+
|   MIGRATION   |                APPLIED                 |
+---------------+----------------------------------------+
| 1_initial.sql | 2022-01-19 16:16:44.622064 +0900 +0900 |
| 2_record.sql  | no                                     |
+---------------+----------------------------------------+
+ ./my-sql-migrate up -config=test-integration/dbconfig.yml -env sqlite
Applied 1 migration
+ ./my-sql-migrate down -config=test-integration/dbconfig.yml -env sqlite
Applied 1 migration
+ ./my-sql-migrate redo -config=test-integration/dbconfig.yml -env sqlite
Migration (redo) failed: Error while parsing 1_initial.sql: Error parsing migration (1_initial.sql): ERROR: The last statement must be ended by a semicolon or '-- +migrate StatementEnd' marker.
			See https://github.com/rubenv/sql-migrate for details.
```