### PR TITLE
Close the database before exiting

### DIFF
--- a/sql-migrate/command_common.go
+++ b/sql-migrate/command_common.go
@@ -16,6 +16,7 @@ func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int) err
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	source := migrate.FileMigrationSource{
 		Dir: env.Dir,

--- a/sql-migrate/command_redo.go
+++ b/sql-migrate/command_redo.go
@@ -54,6 +54,7 @@ func (c *RedoCommand) Run(args []string) int {
 		ui.Error(err.Error())
 		return 1
 	}
+	defer db.Close()
 
 	source := migrate.FileMigrationSource{
 		Dir: env.Dir,

--- a/sql-migrate/command_skip.go
+++ b/sql-migrate/command_skip.go
@@ -63,6 +63,7 @@ func SkipMigrations(dir migrate.MigrationDirection, dryrun bool, limit int) erro
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	source := migrate.FileMigrationSource{
 		Dir: env.Dir,

--- a/sql-migrate/command_status.go
+++ b/sql-migrate/command_status.go
@@ -53,6 +53,7 @@ func (c *StatusCommand) Run(args []string) int {
 		ui.Error(err.Error())
 		return 1
 	}
+	defer db.Close()
 
 	source := migrate.FileMigrationSource{
 		Dir: env.Dir,


### PR DESCRIPTION
The database are currently not closed, which may be logged as a failed connection. For example, MySQL logs as follows if `db.Close` was not called:
```
[Note] Aborted connection N to db: 'xxx' user: 'yyy' host: 'zzz' (Got an error reading communication packets)
```