### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using [modl](https://github.com/jmoiron/modl)? Check out [modl-migrate](https://
 To install the library and command line program, use the following:
 
 ```bash
-go get -v github.com/rubenv/sql-migrate/...
+go install github.com/rubenv/sql-migrate/...@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Beginners might get confused when installing packages and this old command is no more applicable. Changing the installation instruction to use the latest `go install` command is helpful and might potentially save a couple hours of wondering why the `sql-migrate` CLI tool is not being found by the go environment in local.

Closes #213.