### PR TITLE
Add a new option to migrate up/down command to support migration to a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=0               Limit the number of migrations (0 = unlimited).
+  -version               Run migrate up to a specific version, eg: the version number of migration 1_initial.sql is 1.
   -dryrun                Don't apply migrations, just print them.
 ```
 
 The `new` command creates a new empty migration template using the following pattern `<current time>-<name>.sql`.
 
-The `up` command applies all available migrations. By contrast, `down` will only apply one migration by default. This behavior can be changed for both by using the `-limit` parameter.
+The `up` command applies all available migrations. By contrast, `down` will only apply one migration by default. This behavior can be changed for both by using the `-limit` parameter, and the `-version` parameter. Note `-version` has higher priority than `-limit` if you try to use them both.
 
 The `redo` command will unapply the last migration and reapply it. This is useful during development, when you're writing migrations.
 

--- a/migrate.go
+++ b/migrate.go
@@ -525,7 +525,7 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	return migSet.PlanMigration(db, dialect, m, dir, max, version)
 }
 
-func (ms MigrationSet) PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int, versionInt int64) ([]*PlannedMigration, *gorp.DbMap, error) {
+func (ms MigrationSet) PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirection, max int, version int64) ([]*PlannedMigration, *gorp.DbMap, error) {
 	dbMap, err := ms.getMigrationDbMap(db, dialect)
 	if err != nil {
 		return nil, nil, err
@@ -583,17 +583,17 @@ func (ms MigrationSet) PlanMigration(db *sql.DB, dialect string, m MigrationSour
 	toApply := ToApply(migrations, record.Id, dir)
 	toApplyCount := len(toApply)
 
-	if versionInt > 0 {
+	if version > 0 {
 		i := 0
 		for i < len(toApply) {
-			if toApply[i].VersionInt() == versionInt {
+			if toApply[i].VersionInt() == version {
 				toApplyCount = i + 1
 				break
 			}
 			i++
 		}
 		if i == len(toApply) {
-			return nil, nil, newPlanError(&Migration{}, fmt.Errorf("unknown migration with id %d in database", versionInt).Error())
+			return nil, nil, newPlanError(&Migration{}, fmt.Errorf("unknown migration with version id %d in database", version).Error())
 		}
 	} else if max > 0 && max < toApplyCount {
 		toApplyCount = max

--- a/sql-migrate/command_common.go
+++ b/sql-migrate/command_common.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	migrate "github.com/rubenv/sql-migrate"
 )
 
-func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int, version string) error {
+func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int, version int64) error {
 	env, err := GetEnvironment()
 	if err != nil {
 		return fmt.Errorf("Could not parse config: %s", err)
@@ -23,15 +22,8 @@ func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int, ver
 		Dir: env.Dir,
 	}
 
-	version = strings.TrimSpace(version)
-	var targetVersionId int64 = 0
-	if len(version) > 0 {
-		tempMigration := migrate.Migration{Id: version}
-		targetVersionId = tempMigration.VersionInt()
-	}
-
 	if dryrun {
-		migrations, _, err := migrate.PlanMigration(db, dialect, source, dir, limit, targetVersionId)
+		migrations, _, err := migrate.PlanMigration(db, dialect, source, dir, limit, version)
 		if err != nil {
 			return fmt.Errorf("Cannot plan migration: %s", err)
 		}
@@ -40,7 +32,7 @@ func ApplyMigrations(dir migrate.MigrationDirection, dryrun bool, limit int, ver
 			PrintMigration(m, dir)
 		}
 	} else {
-		n, err := migrate.ExecMax(db, dialect, source, dir, limit, targetVersionId)
+		n, err := migrate.ExecMax(db, dialect, source, dir, limit, version)
 		if err != nil {
 			return fmt.Errorf("Migration failed: %s", err)
 		}

--- a/sql-migrate/command_down.go
+++ b/sql-migrate/command_down.go
@@ -21,6 +21,7 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=1               Limit the number of migrations (0 = unlimited).
+  -version               Run migrate up to a specific version, eg: 20221102092308-create-users or 20221102092308.
   -dryrun                Don't apply migrations, just print them.
 
 `
@@ -33,11 +34,13 @@ func (c *DownCommand) Synopsis() string {
 
 func (c *DownCommand) Run(args []string) int {
 	var limit int
+	var version string
 	var dryrun bool
 
 	cmdFlags := flag.NewFlagSet("down", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 1, "Max number of migrations to apply.")
+	cmdFlags.StringVar(&version, "version", "", "Migrate up to a specific version.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
 	ConfigFlags(cmdFlags)
 
@@ -45,7 +48,7 @@ func (c *DownCommand) Run(args []string) int {
 		return 1
 	}
 
-	err := ApplyMigrations(migrate.Down, dryrun, limit)
+	err := ApplyMigrations(migrate.Down, dryrun, limit, version)
 	if err != nil {
 		ui.Error(err.Error())
 		return 1

--- a/sql-migrate/command_down.go
+++ b/sql-migrate/command_down.go
@@ -21,7 +21,7 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=1               Limit the number of migrations (0 = unlimited).
-  -version               Run migrate up to a specific version, eg: 20221102092308-create-users or 20221102092308.
+  -version               Run migrate up to a specific version, eg: the version number of migration 1_initial.sql is 1.
   -dryrun                Don't apply migrations, just print them.
 
 `
@@ -34,13 +34,13 @@ func (c *DownCommand) Synopsis() string {
 
 func (c *DownCommand) Run(args []string) int {
 	var limit int
-	var version string
+	var version int64
 	var dryrun bool
 
 	cmdFlags := flag.NewFlagSet("down", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 1, "Max number of migrations to apply.")
-	cmdFlags.StringVar(&version, "version", "", "Migrate up to a specific version.")
+	cmdFlags.Int64Var(&version, "version", 0, "Migrate up to a specific version.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
 	ConfigFlags(cmdFlags)
 

--- a/sql-migrate/command_down.go
+++ b/sql-migrate/command_down.go
@@ -21,7 +21,7 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=1               Limit the number of migrations (0 = unlimited).
-  -version               Run migrate up to a specific version, eg: the version number of migration 1_initial.sql is 1.
+  -version               Run migrate down to a specific version, eg: the version number of migration 1_initial.sql is 1.
   -dryrun                Don't apply migrations, just print them.
 
 `

--- a/sql-migrate/command_down.go
+++ b/sql-migrate/command_down.go
@@ -40,7 +40,7 @@ func (c *DownCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("down", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 1, "Max number of migrations to apply.")
-	cmdFlags.Int64Var(&version, "version", 0, "Migrate up to a specific version.")
+	cmdFlags.Int64Var(&version, "version", 0, "Migrate down to a specific version.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
 	ConfigFlags(cmdFlags)
 

--- a/sql-migrate/command_redo.go
+++ b/sql-migrate/command_redo.go
@@ -60,7 +60,7 @@ func (c *RedoCommand) Run(args []string) int {
 		Dir: env.Dir,
 	}
 
-	migrations, _, err := migrate.PlanMigration(db, dialect, source, migrate.Down, 1)
+	migrations, _, err := migrate.PlanMigration(db, dialect, source, migrate.Down, 1, 0)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Migration (redo) failed: %v", err))
 		return 1
@@ -73,13 +73,13 @@ func (c *RedoCommand) Run(args []string) int {
 		PrintMigration(migrations[0], migrate.Down)
 		PrintMigration(migrations[0], migrate.Up)
 	} else {
-		_, err := migrate.ExecMax(db, dialect, source, migrate.Down, 1)
+		_, err := migrate.ExecMax(db, dialect, source, migrate.Down, 1, 0)
 		if err != nil {
 			ui.Error(fmt.Sprintf("Migration (down) failed: %s", err))
 			return 1
 		}
 
-		_, err = migrate.ExecMax(db, dialect, source, migrate.Up, 1)
+		_, err = migrate.ExecMax(db, dialect, source, migrate.Up, 1, 0)
 		if err != nil {
 			ui.Error(fmt.Sprintf("Migration (up) failed: %s", err))
 			return 1

--- a/sql-migrate/command_up.go
+++ b/sql-migrate/command_up.go
@@ -21,6 +21,7 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=0               Limit the number of migrations (0 = unlimited).
+  -version               Run migrate up to a specific version, eg: 20221102092308-create-users or 20221102092308.
   -dryrun                Don't apply migrations, just print them.
 
 `
@@ -33,11 +34,13 @@ func (c *UpCommand) Synopsis() string {
 
 func (c *UpCommand) Run(args []string) int {
 	var limit int
+	var version string
 	var dryrun bool
 
 	cmdFlags := flag.NewFlagSet("up", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 0, "Max number of migrations to apply.")
+	cmdFlags.StringVar(&version, "version", "", "Migrate up to a specific version.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
 	ConfigFlags(cmdFlags)
 
@@ -45,7 +48,7 @@ func (c *UpCommand) Run(args []string) int {
 		return 1
 	}
 
-	err := ApplyMigrations(migrate.Up, dryrun, limit)
+	err := ApplyMigrations(migrate.Up, dryrun, limit, version)
 	if err != nil {
 		ui.Error(err.Error())
 		return 1

--- a/sql-migrate/command_up.go
+++ b/sql-migrate/command_up.go
@@ -21,7 +21,7 @@ Options:
   -config=dbconfig.yml   Configuration file to use.
   -env="development"     Environment.
   -limit=0               Limit the number of migrations (0 = unlimited).
-  -version               Run migrate up to a specific version, eg: 20221102092308-create-users or 20221102092308.
+  -version               Run migrate up to a specific version, eg: the version number of migration 1_initial.sql is 1.
   -dryrun                Don't apply migrations, just print them.
 
 `
@@ -34,13 +34,13 @@ func (c *UpCommand) Synopsis() string {
 
 func (c *UpCommand) Run(args []string) int {
 	var limit int
-	var version string
+	var version int64
 	var dryrun bool
 
 	cmdFlags := flag.NewFlagSet("up", flag.ContinueOnError)
 	cmdFlags.Usage = func() { ui.Output(c.Help()) }
 	cmdFlags.IntVar(&limit, "limit", 0, "Max number of migrations to apply.")
-	cmdFlags.StringVar(&version, "version", "", "Migrate up to a specific version.")
+	cmdFlags.Int64Var(&version, "version", 0, "Migrate up to a specific version.")
 	cmdFlags.BoolVar(&dryrun, "dryrun", false, "Don't apply migrations, just print them.")
 	ConfigFlags(cmdFlags)
 


### PR DESCRIPTION
This is yet another way to limit the number of migrations. 
It's easy for users to figure out the target version instead of counting the limit number.