### PR TITLE
Set Id column with max size 4000 where dialect is mssql (sqlserver)

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -814,7 +814,7 @@ Check https://github.com/go-sql-driver/mysql#parsetime for more info.`)
 	table := dbMap.AddTableWithNameAndSchema(MigrationRecord{}, ms.SchemaName, ms.getTableName()).SetKeys(false, "Id")
 	//dbMap.TraceOn("", log.New(os.Stdout, "migrate: ", log.Lmicroseconds))
 
-	if dialect == "oci8" || dialect == "godror" {
+	if dialect == "oci8" || dialect == "godror" || dialect == "mssql" {
 		table.ColMap("Id").SetMaxSize(4000)
 	}
 


### PR DESCRIPTION
Problem:
Using the mssql dialect, when the change control table is going to be created, the column information of the PK id column is nvarchar(max), but the sqlserver does not allow this type of field as index. Returning error "Could not create constraint or index. See previous errors."

Solution:
Including the mssql dialect in the already existing condition of validation of the Id column in for other dialects, the Id column will now have a defined size of 4000 and so when gorp translates to the language of the database, the id field will be nvarchar(4000) , avoiding the current error "Could not create constraint or index. See previous errors."