### PR TITLE
Fix: getMigrationDbMap method incorrectly uses the global migration set

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -818,7 +818,7 @@ Check https://github.com/go-sql-driver/mysql#parsetime for more info.`)
 		table.ColMap("Id").SetMaxSize(4000)
 	}
 
-	if migSet.DisableCreateTable {
+	if ms.DisableCreateTable {
 		return dbMap, nil
 	}
 


### PR DESCRIPTION
Setting `DisableTableCreate` on a `MigrationSet` has no effect because the `getMigrationDbMap` method on `MigrationSet` uses the global `migSet` instead of the instance variable. 

Signed-off-by: Charith Ellawala <charith.ellawala@gmail.com>