### PR TITLE
fix: config example sslmode to require, not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This may be useful if one doesn't want to store credentials in file:
 ```yml
 production:
     dialect: postgres
-    datasource: host=prodhost dbname=proddb user=${DB_USER} password=${DB_PASSWORD} sslmode=required
+    datasource: host=prodhost dbname=proddb user=${DB_USER} password=${DB_PASSWORD} sslmode=require
     dir: migrations
     table: migrations
 ```


### PR DESCRIPTION
sslmode is set to required in the example of dbconfig.yml in the readme, but sslmode has to be one of "require", "verify-full", "verify-ca", or "disable" (https://github.com/lib/pq/blob/381d253611d666974d43dfa634d29fe16ea9e293/ssl.go#L14).