### PR TITLE
Limit Precision of Time values written to Migrations table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
@@ -49,6 +55,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,7 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -390,8 +391,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -94,6 +94,10 @@ func (s *SqliteMigrateSuite) TestMigrateIncremental(c *C) {
 		Migrations: sqliteMigrations[:1],
 	}
 
+	LimitTimePrecision(true)
+	defer func() {
+		LimitTimePrecision(false)
+	}()
 	// Executes one migration
 	n, err := Exec(s.Db, "sqlite3", migrations, Up)
 	c.Assert(err, IsNil)
@@ -415,6 +419,10 @@ func (s *SqliteMigrateSuite) TestSkipMigration(c *C) {
 			},
 		},
 	}
+	LimitTimePrecision(true)
+	defer func() {
+		LimitTimePrecision(false)
+	}()
 	n, err := SkipMax(s.Db, "sqlite3", migrations, Up, 0)
 	// there should be no errors
 	c.Assert(err, IsNil)

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -68,15 +68,15 @@ func GetEnvironment() (*Environment, error) {
 
 	env := config[ConfigEnvironment]
 	if env == nil {
-		return nil, errors.New("No environment: " + ConfigEnvironment)
+		return nil, errors.New("no environment: " + ConfigEnvironment)
 	}
 
 	if env.Dialect == "" {
-		return nil, errors.New("No dialect specified")
+		return nil, errors.New("no dialect specified")
 	}
 
 	if env.DataSource == "" {
-		return nil, errors.New("No data source specified")
+		return nil, errors.New("no data source specified")
 	}
 	env.DataSource = os.ExpandEnv(env.DataSource)
 
@@ -102,13 +102,13 @@ func GetEnvironment() (*Environment, error) {
 func GetConnection(env *Environment) (*sql.DB, string, error) {
 	db, err := sql.Open(env.Dialect, env.DataSource)
 	if err != nil {
-		return nil, "", fmt.Errorf("Cannot connect to database: %w", err)
+		return nil, "", fmt.Errorf("cannot connect to database: %w", err)
 	}
 
 	// Make sure we only accept dialects that were compiled in.
 	_, exists := dialects[env.Dialect]
 	if !exists {
-		return nil, "", fmt.Errorf("Unsupported dialect: %s", env.Dialect)
+		return nil, "", fmt.Errorf("unsupported dialect: %s", env.Dialect)
 	}
 
 	return db, env.Dialect, nil

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -36,12 +36,13 @@ func ConfigFlags(f *flag.FlagSet) {
 }
 
 type Environment struct {
-	Dialect       string `yaml:"dialect"`
-	DataSource    string `yaml:"datasource"`
-	Dir           string `yaml:"dir"`
-	TableName     string `yaml:"table"`
-	SchemaName    string `yaml:"schema"`
-	IgnoreUnknown bool   `yaml:"ignoreunknown"`
+	Dialect            string `yaml:"dialect"`
+	DataSource         string `yaml:"datasource"`
+	Dir                string `yaml:"dir"`
+	TableName          string `yaml:"table"`
+	SchemaName         string `yaml:"schema"`
+	IgnoreUnknown      bool   `yaml:"ignoreunknown"`
+	LimitTimePrecision bool   `yaml:"limitprecision"`
 }
 
 func ReadConfig() (map[string]*Environment, error) {
@@ -92,6 +93,8 @@ func GetEnvironment() (*Environment, error) {
 	}
 
 	migrate.SetIgnoreUnknown(env.IgnoreUnknown)
+
+	migrate.LimitTimePrecision(env.LimitTimePrecision)
 
 	return env, nil
 }

--- a/sql-migrate/config_test.go
+++ b/sql-migrate/config_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func generateFile(lines []string) (string, error) {
+	file, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		file.Close()
+	}()
+
+	for _, l := range lines {
+		file.WriteString(fmt.Sprintf("%s\n", l))
+	}
+
+	return file.Name(), nil
+}
+
+func cleanup(filePath string) error {
+	err := os.Remove(filePath)
+	if err != nil {
+		if !strings.Contains(err.Error(), "no such file or directory") {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestReadConfig(t *testing.T) {
+	// Bad lines
+	lines := []string{
+		"development:",
+		"  dialect: postgres",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  dialect: postgres",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		" schema: public", // Bad line
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err := generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	_, err = ReadConfig()
+	require.Error(t, err)
+
+	// Good config
+	lines = []string{
+		"development:",
+		"  dialect: postgres",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  dialect: postgres",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	envMap, err := ReadConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	require.Equal(t, 2, len(envMap))
+}
+
+func TestGetEnvironment(t *testing.T) {
+	// Bad lines - can't find key
+	lines := []string{
+		"development:",
+		"  dialect: postgres",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  dialect: postgres",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		" schema: public", // Bad line
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err := generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	_, err = GetEnvironment()
+	require.ErrorContains(t, err, "yaml: line 12: did not find expected key")
+
+	// Parseable - unmatched environment
+	lines = []string{
+		"development:",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "foobar"
+	_, err = GetEnvironment()
+	require.ErrorContains(t, err, "no environment: foobar")
+
+	// Error - missing dialect
+	lines = []string{
+		"development:",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "development"
+	_, err = GetEnvironment()
+	require.ErrorContains(t, err, "no dialect")
+
+	// Error - missing datasource
+	lines = []string{
+		"development:",
+		"  dialect: postgres",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: false",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "development"
+	_, err = GetEnvironment()
+	require.ErrorContains(t, err, "no data source")
+
+	// No migration dir
+	lines = []string{
+		"development:",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dialect: postgres",
+		"  schema: public",
+		"  table: migrations",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "development"
+	env, err := GetEnvironment()
+	require.Equal(t, "migrations", env.Dir)
+
+	// Test setting table and absent limitprecision
+	lines = []string{
+		"development:",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dialect: postgres",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "development"
+	env, err = GetEnvironment()
+	require.Equal(t, "migrations", env.TableName)
+	require.False(t, env.LimitTimePrecision)
+
+	// Test setting table and absent limitprecision
+	lines = []string{
+		"development:",
+		"  datasource: host=127.0.0.1 dbname=reporting user=root password=root sslmode=disable",
+		"  dialect: postgres",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+		"  limitprecision: true",
+		"",
+		"docker:",
+		"  datasource: host=portal_db dbname=reporting user=root password=root sslmode=disable",
+		"  dir: my_db/migrations",
+		"  schema: public",
+		"  table: migrations",
+	}
+	configFile, err = generateFile(lines)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = cleanup(configFile)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ConfigFile = configFile
+	ConfigEnvironment = "development"
+	env, err = GetEnvironment()
+	require.True(t, env.LimitTimePrecision)
+}


### PR DESCRIPTION
I am using a database (SingleStore) that can't support more than 6 milliseconds of precision when inserting timestamp values into its database. When migrations are executed, the insert into the tracking table fails. This PR introduces a limit precision option that rounds timestamps prior to their insertion into the migrations table.

I added test coverage on the `sql-parse/config.go` (both my functionality and previously existing).

If this is too specific, the option limit precision option could be modified to provide a variable rounding option so that it's more adaptable/reusable to other scenarios (I know it's a bit niche atm)