### PR TITLE
add HelpWriter and ErrorWriter (#2)

### DIFF
--- a/sql-migrate/main.go
+++ b/sql-migrate/main.go
@@ -38,8 +38,10 @@ func realMain() int {
 				return &SkipCommand{}, nil
 			},
 		},
-		HelpFunc: cli.BasicHelpFunc("sql-migrate"),
-		Version:  GetVersion(),
+		HelpFunc:    cli.BasicHelpFunc("sql-migrate"),
+		HelpWriter:  os.Stdout,
+		ErrorWriter: os.Stderr,
+		Version:     GetVersion(),
 	}
 
 	exitCode, err := cli.Run()


### PR DESCRIPTION
Currently `sql-migrate --version` outputs to stderr instead of stdout

I've added HelpWriter and ErrorWriter to cli.CLI

![image](https://github.com/rubenv/sql-migrate/assets/8986207/28c595d6-9c22-46cd-832f-6af5c387e11f)


https://github.com/mitchellh/cli/blob/784fcd13e857c49c0e5738a19707762f372a3eb3/cli.go#L119