### PR TITLE
Use stderr instead of stdout for ui error writer

### DIFF
--- a/sql-migrate/main.go
+++ b/sql-migrate/main.go
@@ -14,7 +14,7 @@ func main() {
 var ui cli.Ui
 
 func realMain() int {
-	ui = &cli.BasicUi{Writer: os.Stdout}
+	ui = &cli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr}
 
 	cli := &cli.CLI{
 		Args: os.Args[1:],


### PR DESCRIPTION
I would expect error message to go to stderr when returning exit code 1 if migration fails
https://github.com/rubenv/sql-migrate/blob/29b22c8302724a6cf2022a1645bacaa1fd7036fe/sql-migrate/command_up.go#L52

If it's a breaking change or it is intended, you can close this PR