### PR TITLE
implemented optional logger to log details when applying migrations

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,0 +1,11 @@
+package migrate
+
+import (
+	"context"
+)
+
+type Logger interface {
+	Info(context.Context, string, ...any)
+	Warn(context.Context, string, ...any)
+	Error(context.Context, string, ...any)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"context"
+	"fmt"
+)
+
+// Level is a type to represent the log level
+type Level int
+
+const (
+	LevelSilent Level = iota
+	LevelError
+	LevelWarn
+	LevelInfo
+)
+
+type DefaultLogger struct {
+	level  Level
+	writer Writer
+}
+
+type Writer interface {
+	Printf(string, ...interface{})
+}
+
+// DefaultLogWriter is a default implementation of the Writer interface
+// that writes using fmt.Printf
+type DefaultLogWriter struct{}
+
+func (w *DefaultLogWriter) Printf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+// NewDefaultLogger creates a new DefaultLogger with a silent log level
+func NewDefaultLogger() *DefaultLogger {
+	return &DefaultLogger{
+		level:  LevelSilent,
+		writer: &DefaultLogWriter{},
+	}
+}
+
+func (l *DefaultLogger) WithLevel(level Level) *DefaultLogger {
+	l.level = level
+	return l
+}
+
+func (l *DefaultLogger) WithWriter(writer Writer) *DefaultLogger {
+	l.writer = writer
+	return l
+}
+
+func (l *DefaultLogger) Info(_ context.Context, format string, args ...interface{}) {
+	l.logIfPermittedByLevel(LevelInfo, format, args...)
+}
+
+func (l *DefaultLogger) Warn(_ context.Context, format string, args ...interface{}) {
+	l.logIfPermittedByLevel(LevelWarn, format, args...)
+}
+
+func (l *DefaultLogger) Error(_ context.Context, format string, args ...interface{}) {
+	l.logIfPermittedByLevel(LevelError, format, args...)
+}
+
+func (l *DefaultLogger) logIfPermittedByLevel(requiredLevel Level, format string, args ...interface{}) {
+	if l.level < requiredLevel {
+		return
+	}
+	l.writer.Printf(format, args...)
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,79 @@
+package log_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rubenv/sql-migrate/log"
+)
+
+type mockWriter struct {
+	logs []string
+}
+
+func (mw *mockWriter) Printf(format string, args ...interface{}) {
+	mw.logs = append(mw.logs, fmt.Sprintf(format, args...))
+}
+
+func TestDefaultLoggerWithLevelInfo(t *testing.T) {
+	mockWriter := &mockWriter{logs: []string{}}
+
+	logger := log.NewDefaultLogger().WithLevel(log.LevelInfo).WithWriter(mockWriter)
+	logger.Info(context.Background(), "This should be logged")
+	logger.Warn(context.Background(), "This should also be logged")
+	logger.Error(context.Background(), "This should also be logged")
+
+	expectedLogs := []string{
+		"This should be logged",
+		"This should also be logged",
+		"This should also be logged",
+	}
+
+	if len(mockWriter.logs) != len(expectedLogs) {
+		t.Fatalf("Expected %d logs, got %d", len(expectedLogs), len(mockWriter.logs))
+	}
+
+	for i, expectedLog := range expectedLogs {
+		if expectedLog != mockWriter.logs[i] {
+			t.Fatalf("Expected log %d to be %s, got %s", i, expectedLog, mockWriter.logs[i])
+		}
+	}
+}
+
+func TestDefaultLoggerWithLevelSilent(t *testing.T) {
+	mockWriter := &mockWriter{logs: []string{}}
+
+	logger := log.NewDefaultLogger().WithLevel(log.LevelSilent).WithWriter(mockWriter)
+	logger.Info(context.Background(), "This should not be logged")
+	logger.Warn(context.Background(), "This should not be logged")
+	logger.Error(context.Background(), "This should not be logged")
+
+	if len(mockWriter.logs) != 0 {
+		t.Fatalf("Expected no logs, got %d", len(mockWriter.logs))
+	}
+}
+
+func TestDefaultLoggerWithLevelWarn(t *testing.T) {
+	mockWriter := &mockWriter{logs: []string{}}
+
+	logger := log.NewDefaultLogger().WithLevel(log.LevelWarn).WithWriter(mockWriter)
+	logger.Info(context.Background(), "This should not be logged")
+	logger.Warn(context.Background(), "This should be logged")
+	logger.Error(context.Background(), "This should also be logged")
+
+	expectedLogs := []string{
+		"This should be logged",
+		"This should also be logged",
+	}
+
+	if len(mockWriter.logs) != len(expectedLogs) {
+		t.Fatalf("Expected %d logs, got %d", len(expectedLogs), len(mockWriter.logs))
+	}
+
+	for i, expectedLog := range expectedLogs {
+		if expectedLog != mockWriter.logs[i] {
+			t.Fatalf("Expected log %d to be %s, got %s", i, expectedLog, mockWriter.logs[i])
+		}
+	}
+}


### PR DESCRIPTION
Hey, here is a PR for the enhanced logging infos when applying migrations, proposed in https://github.com/rubenv/sql-migrate/issues/266