### PR TITLE
updated golang.org/x/crypto to v0.37.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
         goarch: [amd64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: wangyoucao577/go-release-action@v1.38
+        uses: actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@v1.53
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: 1.20
+          goversion: 1.23
           pre_command: export CGO_ENABLED=0
           project_path: "./sql-migrate"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,111 +1,117 @@
-name: Test
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-jobs:
-  test:
-    strategy:
-      fail-fast: true
-      matrix:
-        go-version: ["1.23", "1.24"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup-go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache: true
-          cache-dependency-path: go.sum
-      - name: go build
-        run: go build -o ./bin/sql-migrate ./sql-migrate && ./bin/sql-migrate --help
-      - name: go test
-        run: go test ./...
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup-go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-          cache: true
-          cache-dependency-path: go.sum
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.64
-      - name: go mod tidy
-        run: go mod tidy
-      - name: check for any changes
-        run: |
-          [[ $(git status --porcelain) == "" ]] || (echo "changes detected" && exit 1)
-  integration:
-    needs:
-      - test
-      - lint
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        go-version: ["1.23", "1.24"]
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "1"
-          MYSQL_ROOT_PASSWORD: ""
-          MYSQL_DATABASE: "test"
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: "password"
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      MYSQL_HOST: "127.0.0.1"
-      PGHOST: "127.0.0.1"
-      PGUSER: "postgres"
-      PGPASSWORD: "password"
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup-go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache: true
-          cache-dependency-path: go.sum
-      - name: setup databases
-        run: |
-          mysql --user=root -e 'CREATE DATABASE IF NOT EXISTS test;'
-          mysql --user=root -e 'CREATE DATABASE IF NOT EXISTS test_env;'
-          psql -U postgres -c 'CREATE DATABASE test;'
-      - name: install sql-migrate
-        run: go install ./...
-      - name: postgres
-        run: bash ./test-integration/postgres.sh
-      - name: mysql
-        run: bash ./test-integration/mysql.sh
-      - name: mysql-flag
-        run: bash ./test-integration/mysql-flag.sh
-      - name: mysql-env
-        run: bash ./test-integration/mysql-env.sh
-      - name: sqlite
-        run: bash ./test-integration/sqlite.sh
+linters-settings:
+  gocritic:
+    disabled-checks:
+      - ifElseChain
+
+  goimports:
+    local-prefixes: github.com/rubenv/sql-migrate
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+
+  depguard:
+    rules:
+      main:
+        allow:
+          - $gostd
+          - github.com/denisenkom/go-mssqldb
+          - github.com/go-sql-driver/mysql
+          - github.com/go-gorp/gorp/v3
+          - github.com/lib/pq
+          - github.com/mattn/go-sqlite3
+          - github.com/mitchellh/cli
+          - github.com/olekukonko/tablewriter
+          - github.com/rubenv/sql-migrate
+          - gopkg.in/check.v1
+          - gopkg.in/yaml.v2
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nolintlint:
+    allow-unused: false
+    allow-no-explanation:
+      - depguard
+    require-explanation: true
+    require-specific: true
+
+  revive:
+    enable-all-rules: false
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: call-to-gc
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: duplicated-imports
+      - name: empty-block
+      - name: empty-lines
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: imports-blocklist
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: package-comments
+      - name: range
+      - name: range-val-address
+      - name: range-val-in-closure
+      - name: receiver-naming
+      - name: string-format
+      - name: string-of-int
+      - name: struct-tag
+      - name: time-naming
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unexported-return
+      - name: superfluous-else
+      - name: unreachable-code
+      - name: var-declaration
+      - name: waitgroup-by-value
+      - name: unused-receiver
+      - name: unnecessary-stmt
+      - name: unused-parameter
+
+run:
+  tests: true
+  timeout: 1m
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - depguard
+    - errcheck
+    - exhaustive
+    - gocritic
+    - gofmt
+    - gofumpt
+    - goimports
+    - govet
+    - ineffassign
+    - nolintlint
+    - revive
+    - staticcheck
+    - typecheck
+    - unused
+    - whitespace
+    - errorlint
+    - gosimple
+    - unparam
+
+issues:
+  exclude:
+    - 'declaration of "err" shadows declaration at'
+    - 'error-strings: error strings should not be capitalized or end with punctuation or a newline'
+  max-same-issues: 10000
+  max-issues-per-linter: 10000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64
       - name: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,117 +1,111 @@
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - ifElseChain
-
-  goimports:
-    local-prefixes: github.com/rubenv/sql-migrate
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-
-  depguard:
-    rules:
-      main:
-        allow:
-          - $gostd
-          - github.com/denisenkom/go-mssqldb
-          - github.com/go-sql-driver/mysql
-          - github.com/go-gorp/gorp/v3
-          - github.com/lib/pq
-          - github.com/mattn/go-sqlite3
-          - github.com/mitchellh/cli
-          - github.com/olekukonko/tablewriter
-          - github.com/rubenv/sql-migrate
-          - gopkg.in/check.v1
-          - gopkg.in/yaml.v2
-
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  nolintlint:
-    allow-unused: false
-    allow-no-explanation:
-      - depguard
-    require-explanation: true
-    require-specific: true
-
-  revive:
-    enable-all-rules: false
-    rules:
-      - name: atomic
-      - name: blank-imports
-      - name: bool-literal-in-expr
-      - name: call-to-gc
-      - name: constant-logical-expr
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: empty-block
-      - name: empty-lines
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-      - name: identical-branches
-      - name: imports-blocklist
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: modifies-parameter
-      - name: modifies-value-receiver
-      - name: package-comments
-      - name: range
-      - name: range-val-address
-      - name: range-val-in-closure
-      - name: receiver-naming
-      - name: string-format
-      - name: string-of-int
-      - name: struct-tag
-      - name: time-naming
-      - name: unconditional-recursion
-      - name: unexported-naming
-      - name: unexported-return
-      - name: superfluous-else
-      - name: unreachable-code
-      - name: var-declaration
-      - name: waitgroup-by-value
-      - name: unused-receiver
-      - name: unnecessary-stmt
-      - name: unused-parameter
-
-run:
-  tests: true
-  timeout: 1m
-
-linters:
-  disable-all: true
-  enable:
-    - asciicheck
-    - depguard
-    - errcheck
-    - exhaustive
-    - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
-    - govet
-    - ineffassign
-    - nolintlint
-    - revive
-    - staticcheck
-    - typecheck
-    - unused
-    - whitespace
-    - errorlint
-    - gosimple
-    - unparam
-
-issues:
-  exclude:
-    - 'declaration of "err" shadows declaration at'
-    - 'error-strings: error strings should not be capitalized or end with punctuation or a newline'
-  max-same-issues: 10000
-  max-issues-per-linter: 10000
+name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        go-version: ["1.23", "1.24"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: go.sum
+      - name: go build
+        run: go build -o ./bin/sql-migrate ./sql-migrate && ./bin/sql-migrate --help
+      - name: go test
+        run: go test ./...
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+          cache-dependency-path: go.sum
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+      - name: go mod tidy
+        run: go mod tidy
+      - name: check for any changes
+        run: |
+          [[ $(git status --porcelain) == "" ]] || (echo "changes detected" && exit 1)
+  integration:
+    needs:
+      - test
+      - lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        go-version: ["1.23", "1.24"]
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "1"
+          MYSQL_ROOT_PASSWORD: ""
+          MYSQL_DATABASE: "test"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: "password"
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      MYSQL_HOST: "127.0.0.1"
+      PGHOST: "127.0.0.1"
+      PGUSER: "postgres"
+      PGPASSWORD: "password"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: go.sum
+      - name: setup databases
+        run: |
+          mysql --user=root -e 'CREATE DATABASE IF NOT EXISTS test;'
+          mysql --user=root -e 'CREATE DATABASE IF NOT EXISTS test_env;'
+          psql -U postgres -c 'CREATE DATABASE test;'
+      - name: install sql-migrate
+        run: go install ./...
+      - name: postgres
+        run: bash ./test-integration/postgres.sh
+      - name: mysql
+        run: bash ./test-integration/mysql.sh
+      - name: mysql-flag
+        run: bash ./test-integration/mysql-flag.sh
+      - name: mysql-env
+        run: bash ./test-integration/mysql-env.sh
+      - name: sqlite
+        run: bash ./test-integration/sqlite.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.55.2
+          version: v1.64
       - name: go mod tidy
         run: go mod tidy
       - name: check for any changes
@@ -85,9 +85,9 @@ jobs:
       PGPASSWORD: "password"
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,12 +2,15 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+
   goimports:
     local-prefixes: github.com/rubenv/sql-migrate
+
   govet:
     enable-all: true
     disable:
       - fieldalignment
+
   depguard:
     rules:
       main:
@@ -21,15 +24,19 @@ linters-settings:
           - github.com/mitchellh/cli
           - github.com/olekukonko/tablewriter
           - github.com/rubenv/sql-migrate
+          - gopkg.in/check.v1
+          - gopkg.in/yaml.v2
+
   exhaustive:
     default-signifies-exhaustive: true
+
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     allow-no-explanation:
       - depguard
     require-explanation: true
     require-specific: true
+
   revive:
     enable-all-rules: false
     rules:
@@ -50,7 +57,7 @@ linters-settings:
       - name: errorf
       - name: exported
       - name: identical-branches
-      - name: imports-blacklist
+      - name: imports-blocklist
       - name: increment-decrement
       - name: indent-error-flow
       - name: modifies-parameter
@@ -74,9 +81,11 @@ linters-settings:
       - name: unused-receiver
       - name: unnecessary-stmt
       - name: unused-parameter
+
 run:
   tests: true
   timeout: 1m
+
 linters:
   disable-all: true
   enable:
@@ -99,9 +108,10 @@ linters:
     - errorlint
     - gosimple
     - unparam
+
 issues:
   exclude:
-    - 'declaration of "err" shadows declaration at' # Allow shadowing of `err` because it's so common
+    - 'declaration of "err" shadows declaration at'
     - 'error-strings: error strings should not be capitalized or end with punctuation or a newline'
   max-same-issues: 10000
   max-issues-per-linter: 10000

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -111,7 +111,7 @@ linters:
 
 issues:
   exclude:
-    - 'declaration of "err" shadows declaration at'
+    - 'declaration of "err" shadows declaration at' # Allow shadowing of `err` because it's so common
     - 'error-strings: error strings should not be capitalized or end with punctuation or a newline'
   max-same-issues: 10000
   max-issues-per-linter: 10000

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rubenv/sql-migrate
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/denisenkom/go-mssqldb v0.9.0
@@ -42,8 +42,8 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
@@ -151,16 +149,13 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
+golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -151,11 +153,14 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/test-integration/mysql-flag.sh
+++ b/test-integration/mysql-flag.sh
@@ -7,4 +7,5 @@ OPTIONS="-config=test-integration/dbconfig.yml -env mysql_noflag"
 
 set -ex
 
-sql-migrate status $OPTIONS | grep -q "Make sure that the parseTime option is supplied"
+sql-migrate status $OPTIONS 2>&1 | grep -q "Make sure that the parseTime option is supplied"
+


### PR DESCRIPTION
updated golang.org/x/crypto to v0.37.0 due to security reasons
bump go version to 1.23 ( due to versions < 1.23 not supported by go security guides )
bump actions & golangci-lint versions