### PR TITLE
Fix invalid Go version format in go.mod (1.23.0 → 1.23)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rubenv/sql-migrate
 
-go 1.23.0
+go 1.23
 
 toolchain go1.24.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rubenv/sql-migrate
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/denisenkom/go-mssqldb v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rubenv/sql-migrate
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/denisenkom/go-mssqldb v0.9.0


### PR DESCRIPTION
Hi 👋

This PR fixes an issue in the go.mod file introduced in tag v1.7.2.

```
go 1.23.0 // ❌ invalid
```
According to the [Go Modules Reference](https://golang.org/ref/mod#go-mod-file-go), the Go version must be in the form of 1.23 without a patch version. Using 1.23.0 causes tools like go install to fail with:

```lua
invalid go version '1.23.0': must match format 1.23

```
This change updates it to:
```
go 1.23 // ✅ valid

```
Thanks!

