### PR TITLE
feat(status_command): add json output option

### DIFF
--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -27,11 +27,13 @@ var dialects = map[string]gorp.Dialect{
 var (
 	ConfigFile        string
 	ConfigEnvironment string
+	OutputFormat      string
 )
 
 func ConfigFlags(f *flag.FlagSet) {
 	f.StringVar(&ConfigFile, "config", "dbconfig.yml", "Configuration file to use.")
 	f.StringVar(&ConfigEnvironment, "env", "development", "Environment to use.")
+	f.StringVar(&OutputFormat, "output", "table", "Output format.")
 }
 
 type Environment struct {


### PR DESCRIPTION
sql-migrate "status" command displays applied and unapplied migrations in a pretty "table" format. Pretty for humans, but not suited for automation.

Introducing a new optional parameter --output to handle JSON output format.

# Tests

## Show help
```
% ~/go/bin/sql-migrate status --help
Usage: sql-migrate status [options] ...

  Show migration status.

Options:

  -config=dbconfig.yml   Configuration file to use.
  -env="development"     Environment.
  -output="json"         Print output in JSON format (default is table format).
```

## No migration applied
```
$ ~/go/bin/sql-migrate status
+-----------+---------+
| MIGRATION | APPLIED |
+-----------+---------+
| 1.sql     | no      |
| 2.sql     | no      |
+-----------+---------+

$ ~/go/bin/sql-migrate status --output json
[
  {
    "migration": "1.sql",
    "applied": "no"
  },
  {
    "migration": "2.sql",
    "applied": "no"
  }
]
```

## Migration applied

```
$ ~/go/bin/sql-migrate up -limit 1
Applied 1 migration

$ ~/go/bin/sql-migrate status
+-----------+---------------------+
| MIGRATION |       APPLIED       |
+-----------+---------------------+
| 1.sql     | 2025-08-26 16:51:28 |
| 2.sql     | no                  |
+-----------+---------------------+

$ ~/go/bin/sql-migrate status --output json
[
  {
    "migration": "1.sql",
    "applied": "2025-08-26T16:51:28+02:00"
  },
  {
    "migration": "2.sql",
    "applied": "no"
  }
]
```

## Default output
Only --output JSON will output in JSON format
```
$ ~/go/bin/sql-migrate status --output table
+-----------+---------------------+
| MIGRATION |       APPLIED       |
+-----------+---------------------+
| 1.sql     | 2025-08-26 16:51:28 |
| 2.sql     | no                  |
+-----------+---------------------+
$ ~/go/bin/sql-migrate status --output anything
+-----------+---------------------+
| MIGRATION |       APPLIED       |
+-----------+---------------------+
| 1.sql     | 2025-08-26 16:51:28 |
| 2.sql     | no                  |
+-----------+---------------------+
```
